### PR TITLE
Feature/2.3.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,10 @@
                             <pattern>net.kyori</pattern>
                             <shadedPattern>de.eldoria.bigdoorsopener.kyori</shadedPattern>
                         </relocation>
+                        <relocation>
+                            <pattern>de.eldoria.eldoutilities</pattern>
+                            <shadedPattern>de.eldoria.bigdoorsopener.eldoutilities</shadedPattern>
+                        </relocation>
                     </relocations>
                 </configuration>
                 <executions>
@@ -122,10 +126,10 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>de.eldoria</groupId>
-            <artifactId>EldoUtilities</artifactId>
-            <version>1.4.2</version>
-            <scope>provided</scope>
+            <groupId>de.eldoria.EldoUtilities</groupId>
+            <artifactId>EldoUtilitiesCore</artifactId>
+            <version>1.7.3</version>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>net.kyori</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>de.eldoria</groupId>
     <artifactId>bigdoorsopener</artifactId>
-    <version>2.3.2</version>
+    <version>2.3.3</version>
     <name>BigDoorsOpener</name>
     <url>https://github.com/eldoriarpg/BigDoorOpener</url>
     <description>Open and close doors automatically on certain conditions</description>

--- a/src/main/java/de/eldoria/bigdoorsopener/conditions/item/interacting/ItemBlock.java
+++ b/src/main/java/de/eldoria/bigdoorsopener/conditions/item/interacting/ItemBlock.java
@@ -114,6 +114,8 @@ public class ItemBlock extends ItemInteraction {
 
                     itemInMainHand.setAmount(amount.getAsInt());
                     ItemBlock itemBlock = new ItemBlock(itemInMainHand, consume.get());
+
+                    messageSender.sendLocalizedMessage(player, "setCondition.clickKeyBlock");
                     // Register Keyhole object at registration listener.
                     RegisterInteraction.getInstance().register(player, (event, mSender) -> {
                         if (event.getAction() != Action.RIGHT_CLICK_BLOCK) {

--- a/src/main/java/de/eldoria/bigdoorsopener/core/BigDoorsOpener.java
+++ b/src/main/java/de/eldoria/bigdoorsopener/core/BigDoorsOpener.java
@@ -80,17 +80,6 @@ public class BigDoorsOpener extends EldoPlugin {
     private WeatherListener weatherListener;
     private RegisterInteraction registerInteraction;
 
-    /**
-     * Get the plugin logger instance.
-     *
-     * @return plugin logger instance
-     */
-    @SuppressWarnings("StaticVariableUsedBeforeInitialization")
-    @NotNull
-    public static Logger logger() {
-        return instance.getLogger();
-    }
-
     @SuppressWarnings("StaticVariableUsedBeforeInitialization")
     public static CachingJSEngine JS() {
         return JS;
@@ -149,7 +138,7 @@ public class BigDoorsOpener extends EldoPlugin {
 
             // Check for updates
             if (config.isCheckUpdates()) {
-                Updater.Butler(new ButlerUpdateData(this, "bdo.command.reload", true, false, 8, "https://plugins.eldoria.de"));
+                Updater.Butler(new ButlerUpdateData(this, "bdo.command.reload", true, false, 8, "https://plugins.eldoria.de")).start();
             }
 
             localizer = ILocalizer.create(this, "de_DE", "en_US");

--- a/src/main/java/de/eldoria/bigdoorsopener/core/BigDoorsOpener.java
+++ b/src/main/java/de/eldoria/bigdoorsopener/core/BigDoorsOpener.java
@@ -61,7 +61,6 @@ import java.util.regex.Pattern;
 
 public class BigDoorsOpener extends EldoPlugin {
 
-    private static Logger logger;
     private static CachingJSEngine JS;
     private static boolean placeholderEnabled = false;
     private static boolean mythicMobsEnabled;
@@ -89,7 +88,7 @@ public class BigDoorsOpener extends EldoPlugin {
     @SuppressWarnings("StaticVariableUsedBeforeInitialization")
     @NotNull
     public static Logger logger() {
-        return logger;
+        return instance.getLogger();
     }
 
     @SuppressWarnings("StaticVariableUsedBeforeInitialization")
@@ -124,20 +123,19 @@ public class BigDoorsOpener extends EldoPlugin {
     }
 
     @Override
-    public void onDisable() {
+    public void onPluginDisable() {
         super.onDisable();
     }
 
-    @SuppressWarnings("AssignmentToStaticFieldFromInstanceMethod")
     @SneakyThrows
+    @SuppressWarnings("AssignmentToStaticFieldFromInstanceMethod")
     @Override
-    public void onEnable() {
+    public void onPluginEnable() {
 
         ServerVersion.forceVersion(ServerVersion.MC_1_8, ServerVersion.MC_1_16);
 
         if (!initialized) {
             instance = this;
-            logger = this.getLogger();
 
             // Load external resources. Must be loaded first.
             loadExternalSources();

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -175,3 +175,4 @@ unregister.message=Door %DOOR_NAME% unregistered.
 warning.chainIsEmpty=The door has no conditions set. The door will not change its state. Maybe you want to unregister it instead.
 warning.valueNotInEvaluator=The condition %VALUE% is missing in the evaluator. It will not have any influence on the door state yet.
 warning.valueStillUsed=The condition %VALUE% is still present in the evaluator. The evaluation will probably not work till it is removed.
+setCondition.clickKeyBlock=Please click on the block which should be the key block.

--- a/src/main/resources/messages_de_DE.properties
+++ b/src/main/resources/messages_de_DE.properties
@@ -175,3 +175,4 @@ unregister.message=Tor %DOOR_NAME% wurde entfernt.
 warning.chainIsEmpty=Dieses Tor hat derzeit keine Bedingungen. Der Zustand wird sich nicht verändern. Vielleicht möchtest du sie lieber entfernen.
 warning.valueNotInEvaluator=Der Bedingung %VALUE% fehlt in der aktuellen Formel. Sie wird derzeit keinerlei Auswirkungen haben.
 warning.valueStillUsed=Die Bedingung %VALUE% wird noch in der Formel benutzt. Der berechnete Zustand wird eventuell nicht korrekt sein.
+setCondition.clickKeyBlock=Bitte klicke auf den Block, welcher der Schlüsselblock sein sollte.

--- a/src/main/resources/messages_en_US.properties
+++ b/src/main/resources/messages_en_US.properties
@@ -175,3 +175,4 @@ unregister.message=Door %DOOR_NAME% unregistered.
 warning.chainIsEmpty=The door has no conditions set. The door will not change its state. Maybe you want to unregister it instead.
 warning.valueNotInEvaluator=The condition %VALUE% is missing in the evaluator. It will not have any influence on the door state yet.
 warning.valueStillUsed=The condition %VALUE% is still present in the evaluator. The evaluation will probably not work till it is removed.
+setCondition.clickKeyBlock=Please click on the block which should be the key block.

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -7,7 +7,6 @@ website: www.spigotmc.org/resources/80805/
 api-version: 1.13
 depend:
   - BigDoors
-  - EldoUtilities
 softdepend:
   - WorldGuard
   - PlaceholderAPI


### PR DESCRIPTION
This patch fixed the broken update checker.
It also fixes a missing message when a item block condition is created. Thanks to MinionToGaming for reporting
This patch fixed a Exception on server shutdown. Thanks to kalebbroo for reporting :3
It also fixes a possible bug if bukkit messes up with the enable order, which causes that depends are loaded after the plugin. Thanks to Esron for helping to figure this out.
