### PR TITLE
Feature/2.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>de.eldoria</groupId>
     <artifactId>bigdoorsopener</artifactId>
-    <version>2.3.3</version>
+    <version>2.4.0-pre5</version>
     <name>BigDoorsOpener</name>
     <url>https://github.com/eldoriarpg/BigDoorOpener</url>
     <description>Open and close doors automatically on certain conditions</description>
@@ -20,7 +20,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.5</version>
+                <version>3.8.1</version>
                 <configuration>
                     <source>8</source>
                     <target>8</target>
@@ -29,7 +29,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.3</version>
+                <version>3.2.4</version>
                 <!-- Do not include the <configuration>...</configuration> part if you are using Sponge! -->
                 <configuration>
                     <relocations>
@@ -126,10 +126,16 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>de.eldoria.EldoUtilities</groupId>
+            <groupId>de.eldoria</groupId>
             <artifactId>EldoUtilitiesCore</artifactId>
-            <version>1.7.3</version>
+            <version>1.7.8</version>
             <scope>compile</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.bstats</groupId>
+                    <artifactId>bstats-bukkit</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>net.kyori</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>de.eldoria</groupId>
     <artifactId>bigdoorsopener</artifactId>
-    <version>2.4.0-pre5</version>
+    <version>2.4.0</version>
     <name>BigDoorsOpener</name>
     <url>https://github.com/eldoriarpg/BigDoorOpener</url>
     <description>Open and close doors automatically on certain conditions</description>

--- a/src/main/java/de/eldoria/bigdoorsopener/commands/BDOCommand.java
+++ b/src/main/java/de/eldoria/bigdoorsopener/commands/BDOCommand.java
@@ -2,6 +2,7 @@ package de.eldoria.bigdoorsopener.commands;
 
 import com.google.common.cache.Cache;
 import de.eldoria.bigdoorsopener.commands.bdosubcommands.About;
+import de.eldoria.bigdoorsopener.commands.bdosubcommands.AddCondition;
 import de.eldoria.bigdoorsopener.commands.bdosubcommands.CloneDoor;
 import de.eldoria.bigdoorsopener.commands.bdosubcommands.CopyCondition;
 import de.eldoria.bigdoorsopener.commands.bdosubcommands.DoorList;
@@ -52,6 +53,7 @@ public class BDOCommand extends EldoCommand {
         registerCommand("reload", new Reload(config, doorChecker, plugin));
         registerCommand("removeCondition", new RemoveCondition(doors, config));
         registerCommand("setCondition", new SetCondition(doors, config));
+        registerCommand("addCondition", new AddCondition(doors, config));
         registerCommand("setEvaluator", new SetEvaluator(doors, config));
         registerCommand("stayOpen", new StayOpen(doors, config));
         registerCommand("unregister", new Unregister(doors, config));

--- a/src/main/java/de/eldoria/bigdoorsopener/commands/bdosubcommands/AddCondition.java
+++ b/src/main/java/de/eldoria/bigdoorsopener/commands/bdosubcommands/AddCondition.java
@@ -1,0 +1,113 @@
+package de.eldoria.bigdoorsopener.commands.bdosubcommands;
+
+import de.eldoria.bigdoorsopener.config.Config;
+import de.eldoria.bigdoorsopener.core.adapter.BigDoorsAdapterCommand;
+import de.eldoria.bigdoorsopener.core.conditions.ConditionContainer;
+import de.eldoria.bigdoorsopener.core.conditions.ConditionRegistrar;
+import de.eldoria.bigdoorsopener.door.ConditionalDoor;
+import de.eldoria.bigdoorsopener.util.Permissions;
+import de.eldoria.eldoutilities.localization.Replacement;
+import de.eldoria.eldoutilities.utils.ArrayUtil;
+import nl.pim16aap2.bigDoors.BigDoors;
+import nl.pim16aap2.bigDoors.Door;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+public class AddCondition extends BigDoorsAdapterCommand {
+
+    public AddCondition(BigDoors bigDoors, Config config) {
+        super(bigDoors, config);
+    }
+
+    @Override
+    public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
+        if (denyAccess(sender, Permissions.USE)) {
+            return true;
+        }
+
+        if (argumentsInvalid(sender, args, 2,
+                "<$syntax.doorId$> <$syntax.condition$> [$syntax.conditionValues$]")) {
+            return true;
+        }
+
+        Player player = getPlayerFromSender(sender);
+
+        Door playerDoor = getPlayerDoor(args[0], player);
+
+        if (playerDoor == null) {
+            return true;
+        }
+
+        ConditionalDoor conditionalDoor = getOrRegister(playerDoor, player);
+
+        if (conditionalDoor == null) {
+            return true;
+        }
+
+        Optional<ConditionContainer> conditionByName = ConditionRegistrar.getConditionByName(args[1]);
+
+        if (!conditionByName.isPresent()) {
+            messageSender().sendLocalizedError(sender, "error.invalidConditionType");
+            return true;
+        }
+
+        ConditionContainer condition = conditionByName.get();
+
+        String group = condition.getGroup();
+
+        if (denyAccess(player, Permissions.getConditionPermission(condition),
+                Permissions.ALL_CONDITION)) {
+            return true;
+        }
+
+        String[] conditionArgs = new String[0];
+        if (args.length > 2) {
+            conditionArgs = Arrays.copyOfRange(args, 2, args.length);
+        }
+
+        condition.create(player, messageSender(), c -> conditionalDoor.getConditionBag().addCondition(c), conditionArgs);
+
+        if (conditionalDoor.getEvaluationType() == ConditionalDoor.EvaluationType.CUSTOM) {
+            Pattern compile = Pattern.compile(group, Pattern.CASE_INSENSITIVE);
+            if (!compile.matcher(conditionalDoor.getEvaluator()).find()) {
+                messageSender().sendLocalizedError(player, "warning.valueNotInEvaluator",
+                        Replacement.create("VALUE", group).addFormatting('6'));
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public @Nullable List<String> onTabComplete(@NotNull CommandSender sender, @NotNull Command command, @NotNull String alias, @NotNull String[] args) {
+        if (args.length == 1) {
+            return getDoorCompletion(sender, args[0]);
+        }
+        if (args.length == 2) {
+            return ArrayUtil.startingWithInArray(args[1], ConditionRegistrar.getConditions().toArray(new String[0])).collect(Collectors.toList());
+        }
+
+        Optional<ConditionContainer> conditionByName = ConditionRegistrar.getConditionByName(args[1]);
+
+        if (!conditionByName.isPresent()) {
+            return Collections.singletonList(localizer().getMessage("error.invalidConditionType"));
+        }
+
+        ConditionContainer container = conditionByName.get();
+
+        if (denyAccess(sender, true, Permissions.getConditionPermission(container.getGroup()), Permissions.ALL_CONDITION)) {
+            return Collections.singletonList(localizer().getMessage("error.permission",
+                    Replacement.create("PERMISSION", Permissions.getConditionPermission(container.getGroup()) + ", " + Permissions.ALL_CONDITION)));
+        }
+        return container.onTabComplete(sender, localizer(), Arrays.copyOfRange(args, 2, args.length));
+    }
+}

--- a/src/main/java/de/eldoria/bigdoorsopener/commands/bdosubcommands/CopyCondition.java
+++ b/src/main/java/de/eldoria/bigdoorsopener/commands/bdosubcommands/CopyCondition.java
@@ -9,7 +9,9 @@ import de.eldoria.bigdoorsopener.door.ConditionalDoor;
 import de.eldoria.bigdoorsopener.door.conditioncollections.ConditionBag;
 import de.eldoria.bigdoorsopener.util.Permissions;
 import de.eldoria.eldoutilities.localization.Replacement;
+import de.eldoria.eldoutilities.utils.ArgumentUtils;
 import de.eldoria.eldoutilities.utils.ArrayUtil;
+import de.eldoria.eldoutilities.utils.Parser;
 import nl.pim16aap2.bigDoors.BigDoors;
 import nl.pim16aap2.bigDoors.Door;
 import org.bukkit.command.Command;
@@ -21,107 +23,124 @@ import org.jetbrains.annotations.Nullable;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.stream.Collectors;
 
 public class CopyCondition extends BigDoorsAdapterCommand {
 
-	public CopyCondition(BigDoors bigDoors, Config config) {
-		super(bigDoors, config);
-	}
+    public CopyCondition(BigDoors bigDoors, Config config) {
+        super(bigDoors, config);
+    }
 
-	@Override
-	public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
-		if (denyAccess(sender, Permissions.USE)) {
-			return true;
-		}
+    @Override
+    public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
+        if (denyAccess(sender, Permissions.USE)) {
+            return true;
+        }
 
-		if (argumentsInvalid(sender, args, 2,
-				"<$syntax.sourceDoor$> <$syntax.targetDoor$> [$syntax.condition$]")) {
-			return true;
-		}
+        if (argumentsInvalid(sender, args, 2,
+                "<$syntax.sourceDoor$> <$syntax.targetDoor$> [$syntax.condition$]")) {
+            return true;
+        }
 
-		Player playerFromSender = getPlayerFromSender(sender);
+        Player playerFromSender = getPlayerFromSender(sender);
 
-		Door playerSourceDoor = getPlayerDoor(args[0], playerFromSender);
+        Door playerSourceDoor = getPlayerDoor(args[0], playerFromSender);
 
-		if (playerSourceDoor == null) {
-			return true;
-		}
+        if (playerSourceDoor == null) {
+            return true;
+        }
 
-		ConditionalDoor sourceDoor = getOrRegister(playerSourceDoor, playerFromSender);
+        ConditionalDoor sourceDoor = getOrRegister(playerSourceDoor, playerFromSender);
 
-		if (sourceDoor == null) {
-			return true;
-		}
+        if (sourceDoor == null) {
+            return true;
+        }
 
-		Door playerTargetDoor = getPlayerDoor(args[1], playerFromSender);
+        Door playerTargetDoor = getPlayerDoor(args[1], playerFromSender);
 
-		if (playerTargetDoor == null) {
-			return true;
-		}
+        if (playerTargetDoor == null) {
+            return true;
+        }
 
-		ConditionalDoor targetDoor = getOrRegister(playerTargetDoor, playerFromSender);
+        ConditionalDoor targetDoor = getOrRegister(playerTargetDoor, playerFromSender);
 
-		if (targetDoor == null) {
-			return true;
-		}
+        if (targetDoor == null) {
+            return true;
+        }
 
-		ConditionBag sourceBag = sourceDoor.getConditionBag();
+        ConditionBag sourceBag = sourceDoor.getConditionBag();
 
-		if (args.length == 2) {
-			if (denyAccess(sender, Permissions.ALL_CONDITION)) {
-				return true;
-			}
+        if (args.length == 2) {
+            if (denyAccess(sender, Permissions.ALL_CONDITION)) {
+                return true;
+            }
 
-			targetDoor.setConditionBag(sourceBag.copy());
-			messageSender().sendLocalizedMessage(sender, "copyCondition.copiedAll",
-					Replacement.create("SOURCE", playerSourceDoor.getName()).addFormatting('6'),
-					Replacement.create("TARGET", playerTargetDoor.getName()).addFormatting('6'));
-			return true;
-		}
+            targetDoor.setConditionBag(sourceBag.copy());
+            messageSender().sendLocalizedMessage(sender, "copyCondition.copiedAll",
+                    Replacement.create("SOURCE", playerSourceDoor.getName()).addFormatting('6'),
+                    Replacement.create("TARGET", playerTargetDoor.getName()).addFormatting('6'));
+            return true;
+        }
 
-		Optional<ConditionGroup> optionalGroup = ConditionRegistrar.getConditionGroup(args[2]);
+        Optional<ConditionGroup> optionalGroup = ConditionRegistrar.getConditionGroup(args[2]);
 
-		if (!optionalGroup.isPresent()) {
-			messageSender().sendLocalizedError(sender, "error.invalidConditionType");
-			return true;
-		}
+        if (!optionalGroup.isPresent()) {
+            messageSender().sendLocalizedError(sender, "error.invalidConditionType");
+            return true;
+        }
 
-		ConditionGroup conditionGroup = optionalGroup.get();
+        ConditionGroup conditionGroup = optionalGroup.get();
 
-		if (denyAccess(sender, Permissions.getConditionPermission(conditionGroup.getName()), Permissions.ALL_CONDITION)) {
-			return true;
-		}
+        if (denyAccess(sender, Permissions.getConditionPermission(conditionGroup.getName()), Permissions.ALL_CONDITION)) {
+            return true;
+        }
 
-		ConditionBag targetBag = targetDoor.getConditionBag();
+        ConditionBag targetBag = targetDoor.getConditionBag();
 
-		Optional<DoorCondition> condition = sourceBag.getCondition(conditionGroup);
 
-		if (!condition.isPresent()) {
+        String id = ArgumentUtils.getOrDefault(args, 2, "0");
+        OptionalInt optionalInt = Parser.parseInt(id);
+        if (!optionalInt.isPresent()) {
+            messageSender().sendLocalizedError(sender, "error.invalidNumber");
+            return true;
+        }
+
+        List<DoorCondition> condition = sourceBag.getConditions(conditionGroup);
+
+        if (condition.isEmpty()) {
+            messageSender().sendLocalizedError(sender, "error.conditionNotSet");
+            return true;
+        }
+
+		if (condition.size() < optionalInt.getAsInt()) {
 			messageSender().sendLocalizedError(sender, "error.conditionNotSet");
 			return true;
 		}
 
-		targetBag.putCondition(condition.get().clone());
+		targetBag.setCondition(condition.get(optionalInt.getAsInt()).clone());
 
-		messageSender().sendLocalizedMessage(sender, "copyCondition.copiedSingle",
-				Replacement.create("CONDITION", conditionGroup.getName()).addFormatting('6'),
-				Replacement.create("SOURCE", playerSourceDoor.getName()).addFormatting('6'),
-				Replacement.create("TARGET", playerTargetDoor.getName()).addFormatting('6'));
-		return true;
-	}
+        messageSender().sendLocalizedMessage(sender, "copyCondition.copiedSingle",
+                Replacement.create("CONDITION", conditionGroup.getName()).addFormatting('6'),
+                Replacement.create("SOURCE", playerSourceDoor.getName()).addFormatting('6'),
+                Replacement.create("TARGET", playerTargetDoor.getName()).addFormatting('6'));
+        return true;
+    }
 
-	@Override
-	public @Nullable List<String> onTabComplete(@NotNull CommandSender sender, @NotNull Command command, @NotNull String alias, @NotNull String[] args) {
-		if (args.length == 1) {
-			return getDoorCompletion(sender, args[0]);
-		}
-		if (args.length == 2) {
-			return getDoorCompletion(sender, args[1]);
-		}
-		if (args.length == 3) {
-			return ArrayUtil.startingWithInArray(args[2], ConditionRegistrar.getGroups().toArray(new String[0])).collect(Collectors.toList());
-		}
-		return Collections.emptyList();
-	}
+    @Override
+    public @Nullable List<String> onTabComplete(@NotNull CommandSender sender, @NotNull Command command, @NotNull String alias, @NotNull String[] args) {
+        if (args.length == 1) {
+            return getDoorCompletion(sender, args[0]);
+        }
+        if (args.length == 2) {
+            return getDoorCompletion(sender, args[1]);
+        }
+        if (args.length == 3) {
+            return ArrayUtil.startingWithInArray(args[2], ConditionRegistrar.getGroups().toArray(new String[0])).collect(Collectors.toList());
+        }
+        if (args.length == 4) {
+            return Collections.singletonList(localizer().getMessage("tabcomplete.conditionId"));
+        }
+        return Collections.emptyList();
+    }
 }

--- a/src/main/java/de/eldoria/bigdoorsopener/commands/bdosubcommands/GiveKey.java
+++ b/src/main/java/de/eldoria/bigdoorsopener/commands/bdosubcommands/GiveKey.java
@@ -42,7 +42,7 @@ public class GiveKey extends BigDoorsAdapterCommand {
 
     @Override
     public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
-        if (denyAccess(sender, Permissions.USE)) {
+        if (denyAccess(sender, Permissions.GIVE_KEY)) {
             return true;
         }
 

--- a/src/main/java/de/eldoria/bigdoorsopener/commands/bdosubcommands/GiveKey.java
+++ b/src/main/java/de/eldoria/bigdoorsopener/commands/bdosubcommands/GiveKey.java
@@ -3,14 +3,11 @@ package de.eldoria.bigdoorsopener.commands.bdosubcommands;
 import de.eldoria.bigdoorsopener.conditions.DoorCondition;
 import de.eldoria.bigdoorsopener.conditions.item.Item;
 import de.eldoria.bigdoorsopener.config.Config;
-import de.eldoria.bigdoorsopener.core.BigDoorsOpener;
 import de.eldoria.bigdoorsopener.core.adapter.BigDoorsAdapterCommand;
 import de.eldoria.bigdoorsopener.door.ConditionalDoor;
 import de.eldoria.bigdoorsopener.util.Permissions;
 import de.eldoria.eldoutilities.container.Pair;
-import de.eldoria.eldoutilities.localization.Localizer;
 import de.eldoria.eldoutilities.localization.Replacement;
-import de.eldoria.eldoutilities.messages.MessageSender;
 import de.eldoria.eldoutilities.utils.ArgumentUtils;
 import de.eldoria.eldoutilities.utils.Parser;
 import nl.pim16aap2.bigDoors.BigDoors;
@@ -26,13 +23,8 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.stream.Collectors;
-
-import static de.eldoria.bigdoorsopener.commands.CommandHelper.argumentsInvalid;
-import static de.eldoria.bigdoorsopener.commands.CommandHelper.denyAccess;
-import static de.eldoria.bigdoorsopener.commands.CommandHelper.getPlayerFromSender;
 
 public class GiveKey extends BigDoorsAdapterCommand {
 
@@ -66,14 +58,26 @@ public class GiveKey extends BigDoorsAdapterCommand {
             return true;
         }
 
-        Optional<DoorCondition> condition = door.first.getConditionBag().getCondition("item");
+        List<DoorCondition> condition = door.first.getConditionBag().getConditions("item");
 
-        if (!condition.isPresent()) {
+        if (!condition.isEmpty()) {
             messageSender().sendLocalizedError(sender, "error.noItemConditionSet");
             return true;
         }
 
-        ItemStack item = ((Item) condition.get()).getItem();
+        String id = ArgumentUtils.getOrDefault(args, 1, "0");
+        OptionalInt optionalInt = Parser.parseInt(id);
+        if (!optionalInt.isPresent()) {
+            messageSender().sendLocalizedError(sender, "error.invalidNumber");
+            return true;
+        }
+
+        if (condition.size() < optionalInt.getAsInt()) {
+            messageSender().sendLocalizedError(sender, "error.conditionNotSet");
+            return true;
+        }
+
+        ItemStack item = ((Item) condition.get(optionalInt.getAsInt())).getItem();
 
         OptionalInt amount = ArgumentUtils.getOptionalParameter(args, 1, OptionalInt.of(64), Parser::parseInt);
 
@@ -126,6 +130,9 @@ public class GiveKey extends BigDoorsAdapterCommand {
                     .filter(p -> p.getName().toLowerCase().startsWith(args[2]))
                     .map(HumanEntity::getName)
                     .collect(Collectors.toList());
+        }
+        if (args.length == 4) {
+            return Collections.singletonList(localizer().getMessage("tabcomplete.conditionId"));
         }
         return Collections.emptyList();
     }

--- a/src/main/java/de/eldoria/bigdoorsopener/commands/bdosubcommands/Info.java
+++ b/src/main/java/de/eldoria/bigdoorsopener/commands/bdosubcommands/Info.java
@@ -2,14 +2,14 @@ package de.eldoria.bigdoorsopener.commands.bdosubcommands;
 
 import de.eldoria.bigdoorsopener.conditions.DoorCondition;
 import de.eldoria.bigdoorsopener.config.Config;
-import de.eldoria.bigdoorsopener.core.BigDoorsOpener;
 import de.eldoria.bigdoorsopener.core.adapter.BigDoorsAdapterCommand;
+import de.eldoria.bigdoorsopener.core.conditions.ConditionContainer;
+import de.eldoria.bigdoorsopener.core.conditions.ConditionRegistrar;
 import de.eldoria.bigdoorsopener.door.ConditionalDoor;
 import de.eldoria.bigdoorsopener.door.conditioncollections.ConditionBag;
 import de.eldoria.bigdoorsopener.util.C;
 import de.eldoria.bigdoorsopener.util.Permissions;
 import de.eldoria.eldoutilities.container.Pair;
-import de.eldoria.eldoutilities.localization.Localizer;
 import net.kyori.adventure.platform.bukkit.BukkitAudiences;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
@@ -26,98 +26,99 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
-
-import static de.eldoria.bigdoorsopener.commands.CommandHelper.argumentsInvalid;
-import static de.eldoria.bigdoorsopener.commands.CommandHelper.denyAccess;
-import static de.eldoria.bigdoorsopener.commands.CommandHelper.getPlayerFromSender;
+import java.util.Map;
+import java.util.Optional;
 
 public class Info extends BigDoorsAdapterCommand {
-	private final BukkitAudiences bukkitAudiences;
+    private final BukkitAudiences bukkitAudiences;
 
-	public Info(BigDoors bigDoors, Plugin plugin, Config config) {
-		super(bigDoors, config);
-		bukkitAudiences = BukkitAudiences.create(plugin);
-	}
+    public Info(BigDoors bigDoors, Plugin plugin, Config config) {
+        super(bigDoors, config);
+        bukkitAudiences = BukkitAudiences.create(plugin);
+    }
 
-	@Override
-	public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
-		if (denyAccess(sender, Permissions.USE)) {
-			return true;
-		}
+    @Override
+    public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
+        if (denyAccess(sender, Permissions.USE)) {
+            return true;
+        }
 
-		if (argumentsInvalid(sender, args, 1, "<$syntax.doorId$>")) {
-			return true;
-		}
+        if (argumentsInvalid(sender, args, 1, "<$syntax.doorId$>")) {
+            return true;
+        }
 
-		Player playerFromSender = getPlayerFromSender(sender);
+        Player playerFromSender = getPlayerFromSender(sender);
 
-		Pair<ConditionalDoor, Door> door = getConditionalPlayerDoor(args[0], playerFromSender);
-		if (door == null) {
-			return true;
-		}
+        Pair<ConditionalDoor, Door> door = getConditionalPlayerDoor(args[0], playerFromSender);
+        if (door == null) {
+            return true;
+        }
 
-		ConditionalDoor cDoor = door.first;
-		TextComponent.Builder component = Component.text()
-				.append(Component.text(door.second.getName() + " ", C.highlightColor, TextDecoration.BOLD))
-				.append(Component.text("(Id:" + door.second.getDoorUID() + ") ", C.highlightColor, TextDecoration.BOLD))
-				.append(Component.text(localizer().getMessage("info.info"), C.baseColor, TextDecoration.BOLD))
-				.append(Component.newline())
-				.append(Component.text(localizer().getMessage("info.state") + " ", C.baseColor))
-				.append(Component.text(localizer().getMessage(cDoor.isEnabled() ? "info.state.enabled" : "info.state.disabled"), C.highlightColor))
-				.append(Component.newline())
-				.append(Component.text(localizer().getMessage("info.world") + " ", C.baseColor))
-				.append(Component.text(cDoor.getWorld(), C.highlightColor))
-				.append(Component.newline())
-				.append(Component.text(""));
+        ConditionalDoor cDoor = door.first;
+        TextComponent.Builder component = Component.text()
+                .append(Component.text(door.second.getName() + " ", C.highlightColor, TextDecoration.BOLD))
+                .append(Component.text("(Id:" + door.second.getDoorUID() + ") ", C.highlightColor, TextDecoration.BOLD))
+                .append(Component.text(localizer().getMessage("info.info"), C.baseColor, TextDecoration.BOLD))
+                .append(Component.newline())
+                .append(Component.text(localizer().getMessage("info.state") + " ", C.baseColor))
+                .append(Component.text(localizer().getMessage(cDoor.isEnabled() ? "info.state.enabled" : "info.state.disabled"), C.highlightColor))
+                .append(Component.newline())
+                .append(Component.text(localizer().getMessage("info.world") + " ", C.baseColor))
+                .append(Component.text(cDoor.getWorld(), C.highlightColor))
+                .append(Component.newline())
+                .append(Component.text(""));
 
-		// append evaluator
-		component.append(Component.text(localizer().getMessage("info.evaluator") + " ", C.baseColor));
-		if (cDoor.getEvaluationType() == ConditionalDoor.EvaluationType.CUSTOM) {
-			component.append(Component.text(cDoor.getEvaluator() + " ", C.highlightColor))
-					.append(Component.text("[" + localizer().getMessage("info.edit") + "]", NamedTextColor.GREEN, TextDecoration.UNDERLINED)
-							.clickEvent(ClickEvent.suggestCommand("/bdo setEvaluator " + cDoor.getDoorUID() + " custom " + cDoor.getEvaluator())));
-		} else {
-			component.append(Component.text(cDoor.getEvaluationType().name(), C.highlightColor));
-		}
-		component.append(Component.newline());
+        // append evaluator
+        component.append(Component.text(localizer().getMessage("info.evaluator") + " ", C.baseColor));
+        if (cDoor.getEvaluationType() == ConditionalDoor.EvaluationType.CUSTOM) {
+            component.append(Component.text(cDoor.getEvaluator() + " ", C.highlightColor))
+                    .append(Component.text("[" + localizer().getMessage("info.edit") + "]", NamedTextColor.GREEN, TextDecoration.UNDERLINED)
+                            .clickEvent(ClickEvent.suggestCommand("/bdo setEvaluator " + cDoor.getDoorUID() + " custom " + cDoor.getEvaluator())));
+        } else {
+            component.append(Component.text(cDoor.getEvaluationType().name(), C.highlightColor));
+        }
+        component.append(Component.newline());
 
-		// append open time
-		component.append(Component.text(localizer().getMessage("info.stayOpen") + " ", C.baseColor))
-				.append(Component.text(cDoor.getStayOpen() + " ",C.highlightColor))
-				.append(Component.text("[" + localizer().getMessage("info.edit") + "]", NamedTextColor.GREEN, TextDecoration.UNDERLINED)
-						.clickEvent(ClickEvent.suggestCommand("/bdo stayOpen " + cDoor.getDoorUID() + " " + cDoor.getStayOpen())))
-				.append(Component.newline());
+        // append open time
+        component.append(Component.text(localizer().getMessage("info.stayOpen") + " ", C.baseColor))
+                .append(Component.text(cDoor.getStayOpen() + " ", C.highlightColor))
+                .append(Component.text("[" + localizer().getMessage("info.edit") + "]", NamedTextColor.GREEN, TextDecoration.UNDERLINED)
+                        .clickEvent(ClickEvent.suggestCommand("/bdo stayOpen " + cDoor.getDoorUID() + " " + cDoor.getStayOpen())))
+                .append(Component.newline());
 
-		// start of key list
-		component.append(Component.text(localizer().getMessage("info.conditions"), C.highlightColor, TextDecoration.BOLD));
+        // start of key list
+        component.append(Component.text(localizer().getMessage("info.conditions"), C.highlightColor, TextDecoration.BOLD));
 
-		ConditionBag conditionBag = cDoor.getConditionBag();
+        ConditionBag conditionBag = cDoor.getConditionBag();
 
-		for (DoorCondition condition : conditionBag.getConditions()) {
+        Map<String, Integer> groupCount = new HashMap<>();
+
+        for (DoorCondition condition : conditionBag.getConditions()) {
             Optional<ConditionContainer> containerByClass = ConditionRegistrar.getContainerByClass(condition.getClass());
             Integer id = groupCount.compute(containerByClass.get().getGroup(), (k, v) -> v == null ? 0 : v + 1);
-			component.append(Component.newline())
+            component.append(Component.newline())
                     .append(Component.text(id + " | ", NamedTextColor.AQUA))
-					.append(condition.getDescription(localizer()))
-					.append(Component.newline())
-					.append(Component.text("[" + localizer().getMessage("info.remove") + "]", NamedTextColor.DARK_RED, TextDecoration.UNDERLINED)
-							.clickEvent(ClickEvent.runCommand(condition.getRemoveCommand(cDoor))))
-					.append(Component.text(" "))
-					.append(Component.text("[" + localizer().getMessage("info.edit") + "]", NamedTextColor.GREEN, TextDecoration.UNDERLINED)
-							.clickEvent(ClickEvent.suggestCommand(condition.getCreationCommand(cDoor))));
-		}
+                    .append(condition.getDescription(localizer()))
+                    .append(Component.newline())
+                    .append(Component.text("[" + localizer().getMessage("info.remove") + "]", NamedTextColor.DARK_RED, TextDecoration.UNDERLINED)
+                            .clickEvent(ClickEvent.runCommand(condition.getRemoveCommand(cDoor) + " " + id)))
+                    .append(Component.text(" "))
+                    .append(Component.text("[" + localizer().getMessage("info.edit") + "]", NamedTextColor.GREEN, TextDecoration.UNDERLINED)
+                            .clickEvent(ClickEvent.suggestCommand(condition.getCreationCommand(cDoor))));
+        }
 
-		bukkitAudiences.sender(sender).sendMessage(component.build());
-		return true;
+        bukkitAudiences.sender(sender).sendMessage(component.build());
+        return true;
 
-	}
+    }
 
-	@Override
-	public @Nullable List<String> onTabComplete(@NotNull CommandSender sender, @NotNull Command command, @NotNull String alias, @NotNull String[] args) {
-		if (args.length == 1) {
-			return getDoorCompletion(sender, args[0]);
-		}
-		return Collections.emptyList();
-	}
+    @Override
+    public @Nullable List<String> onTabComplete(@NotNull CommandSender sender, @NotNull Command command, @NotNull String alias, @NotNull String[] args) {
+        if (args.length == 1) {
+            return getDoorCompletion(sender, args[0]);
+        }
+        return Collections.emptyList();
+    }
 }

--- a/src/main/java/de/eldoria/bigdoorsopener/commands/bdosubcommands/Info.java
+++ b/src/main/java/de/eldoria/bigdoorsopener/commands/bdosubcommands/Info.java
@@ -95,7 +95,10 @@ public class Info extends BigDoorsAdapterCommand {
 		ConditionBag conditionBag = cDoor.getConditionBag();
 
 		for (DoorCondition condition : conditionBag.getConditions()) {
+            Optional<ConditionContainer> containerByClass = ConditionRegistrar.getContainerByClass(condition.getClass());
+            Integer id = groupCount.compute(containerByClass.get().getGroup(), (k, v) -> v == null ? 0 : v + 1);
 			component.append(Component.newline())
+                    .append(Component.text(id + " | ", NamedTextColor.AQUA))
 					.append(condition.getDescription(localizer()))
 					.append(Component.newline())
 					.append(Component.text("[" + localizer().getMessage("info.remove") + "]", NamedTextColor.DARK_RED, TextDecoration.UNDERLINED)

--- a/src/main/java/de/eldoria/bigdoorsopener/commands/bdosubcommands/RemoveCondition.java
+++ b/src/main/java/de/eldoria/bigdoorsopener/commands/bdosubcommands/RemoveCondition.java
@@ -8,7 +8,9 @@ import de.eldoria.bigdoorsopener.door.ConditionalDoor;
 import de.eldoria.bigdoorsopener.door.conditioncollections.ConditionBag;
 import de.eldoria.bigdoorsopener.util.Permissions;
 import de.eldoria.eldoutilities.localization.Replacement;
+import de.eldoria.eldoutilities.utils.ArgumentUtils;
 import de.eldoria.eldoutilities.utils.ArrayUtil;
+import de.eldoria.eldoutilities.utils.Parser;
 import nl.pim16aap2.bigDoors.BigDoors;
 import nl.pim16aap2.bigDoors.Door;
 import org.bukkit.command.Command;
@@ -20,88 +22,101 @@ import org.jetbrains.annotations.Nullable;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 public class RemoveCondition extends BigDoorsAdapterCommand {
 
-	public RemoveCondition(BigDoors bigDoors, Config config) {
-		super(bigDoors, config);
-	}
+    public RemoveCondition(BigDoors bigDoors, Config config) {
+        super(bigDoors, config);
+    }
 
-	@Override
-	public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
-		if (denyAccess(sender, Permissions.USE)) {
-			return true;
-		}
+    @Override
+    public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
+        if (denyAccess(sender, Permissions.USE)) {
+            return true;
+        }
 
-		if (argumentsInvalid(sender, args, 2,
-				"<$syntax.doorId$> <$syntax.condition$>")){
-			return false;
-		}
+        if (argumentsInvalid(sender, args, 2,
+                "<$syntax.doorId$> <$syntax.condition$>")) {
+            return false;
+        }
 
-		Player playerFromSender = getPlayerFromSender(sender);
+        Player playerFromSender = getPlayerFromSender(sender);
 
-		Door playerDoor = getPlayerDoor(args[0], playerFromSender);
+        Door playerDoor = getPlayerDoor(args[0], playerFromSender);
 
-		if (playerDoor == null) {
-			return true;
-		}
+        if (playerDoor == null) {
+            return true;
+        }
 
-		ConditionalDoor cDoor = getOrRegister(playerDoor, playerFromSender);
+        ConditionalDoor cDoor = getOrRegister(playerDoor, playerFromSender);
 
-		if (cDoor == null) {
-			return true;
-		}
+        if (cDoor == null) {
+            return true;
+        }
 
-		Optional<ConditionGroup> optionalGroup = ConditionRegistrar.getConditionGroup(args[1]);
+        Optional<ConditionGroup> optionalGroup = ConditionRegistrar.getConditionGroup(args[1]);
 
-		if (!optionalGroup.isPresent()) {
-			messageSender().sendLocalizedError(sender, "error.invalidConditionType");
-			return true;
-		}
-		ConditionGroup container = optionalGroup.get();
+        if (!optionalGroup.isPresent()) {
+            messageSender().sendLocalizedError(sender, "error.invalidConditionType");
+            return true;
+        }
+        ConditionGroup container = optionalGroup.get();
 
-		String group = container.getName();
+        String group = container.getName();
 
-		if (denyAccess(sender, Permissions.getConditionPermission(group), Permissions.ALL_CONDITION)) {
-			return true;
-		}
+        if (denyAccess(sender, Permissions.getConditionPermission(group), Permissions.ALL_CONDITION)) {
+            return true;
+        }
 
-		ConditionBag conditionBag = cDoor.getConditionBag();
+        ConditionBag conditionBag = cDoor.getConditionBag();
 
-		if (!conditionBag.isConditionSet(container)) {
-			messageSender().sendLocalizedError(sender, "error.conditionNotSet");
-			return true;
-		} else {
-			conditionBag.removeCondition(container);
-		}
+        if (!conditionBag.isConditionSet(container)) {
+            messageSender().sendLocalizedError(sender, "error.conditionNotSet");
+            return true;
+        } else {
+            String id = ArgumentUtils.getOrDefault(args, 2, "0");
+            OptionalInt optionalInt = Parser.parseInt(id);
+            if (!optionalInt.isPresent()) {
+                messageSender().sendLocalizedError(sender, "error.invalidNumber");
+                return true;
+            }
+            if (!conditionBag.removeCondition(container, optionalInt.getAsInt())) {
+                messageSender().sendLocalizedError(sender, "error.conditionNotSet");
+                return true;
+            }
+        }
 
-		messageSender().sendLocalizedMessage(sender, "removeCondition." + group);
+        messageSender().sendLocalizedMessage(sender, "removeCondition." + group);
 
-		// check if condition is in evaluator if a custom evaluator is present.
-		if (cDoor.getEvaluationType() == ConditionalDoor.EvaluationType.CUSTOM) {
-			Pattern compile = Pattern.compile(group, Pattern.CASE_INSENSITIVE);
-			if (compile.matcher(cDoor.getEvaluator()).find()) {
-				messageSender().sendLocalizedError(sender, "warning.valueStillUsed",
-						Replacement.create("VALUE", group).addFormatting('6'));
-			}
-		}
+        // check if condition is in evaluator if a custom evaluator is present.
+        if (cDoor.getEvaluationType() == ConditionalDoor.EvaluationType.CUSTOM) {
+            Pattern compile = Pattern.compile(group, Pattern.CASE_INSENSITIVE);
+            if (compile.matcher(cDoor.getEvaluator()).find()) {
+                messageSender().sendLocalizedError(sender, "warning.valueStillUsed",
+                        Replacement.create("VALUE", group).addFormatting('6'));
+            }
+        }
 
-		if (conditionBag.isEmpty()) {
-			messageSender().sendLocalizedMessage(sender, "warning.chainIsEmpty");
-		}
-		return true;
-	}
+        if (conditionBag.isEmpty()) {
+            messageSender().sendLocalizedMessage(sender, "warning.chainIsEmpty");
+        }
+        return true;
+    }
 
-	@Override
-	public @Nullable List<String> onTabComplete(@NotNull CommandSender sender, @NotNull Command command, @NotNull String alias, @NotNull String[] args) {
-		if (args.length == 1) {
-			return getDoorCompletion(sender, args[0]);
-		}
-		if (args.length == 2) {
-			return ArrayUtil.startingWithInArray(args[1], ConditionRegistrar.getGroups().toArray(new String[0])).collect(Collectors.toList());
-		}
-		return Collections.emptyList();
-	}
+    @Override
+    public @Nullable List<String> onTabComplete(@NotNull CommandSender sender, @NotNull Command command, @NotNull String alias, @NotNull String[] args) {
+        if (args.length == 1) {
+            return getDoorCompletion(sender, args[0]);
+        }
+        if (args.length == 2) {
+            return ArrayUtil.startingWithInArray(args[1], ConditionRegistrar.getGroups().toArray(new String[0])).collect(Collectors.toList());
+        }
+        if (args.length == 3) {
+            return Collections.singletonList(localizer().getMessage("tabcomplete.conditionId"));
+        }
+        return Collections.emptyList();
+    }
 }

--- a/src/main/java/de/eldoria/bigdoorsopener/commands/bdosubcommands/SetCondition.java
+++ b/src/main/java/de/eldoria/bigdoorsopener/commands/bdosubcommands/SetCondition.java
@@ -83,7 +83,7 @@ public class SetCondition extends BigDoorsAdapterCommand {
             conditionArgs = Arrays.copyOfRange(args, 2, args.length);
         }
 
-        condition.create(player, messageSender(), conditionalDoor.getConditionBag(), conditionArgs);
+        condition.create(player, messageSender(), c -> conditionalDoor.getConditionBag().setCondition(c), conditionArgs);
 
         if (conditionalDoor.getEvaluationType() == ConditionalDoor.EvaluationType.CUSTOM) {
             Pattern compile = Pattern.compile(group, Pattern.CASE_INSENSITIVE);

--- a/src/main/java/de/eldoria/bigdoorsopener/conditions/DoorCondition.java
+++ b/src/main/java/de/eldoria/bigdoorsopener/conditions/DoorCondition.java
@@ -16,67 +16,67 @@ import org.jetbrains.annotations.Nullable;
  * A interface which represents a condition which opens a door under specific circumstances.
  */
 public interface DoorCondition extends ConfigurationSerializable, Cloneable {
-	String SET_COMMAND = "/bdo setCondition ";
-	String REMOVE_COMMAND = "/bdo removeCondition ";
+    String SET_COMMAND = "/bdo setCondition ";
+    String REMOVE_COMMAND = "/bdo removeCondition ";
 
-	static ILocalizer localizer() {
-		return BigDoorsOpener.localizer();
-	}
+    static ILocalizer localizer() {
+        return BigDoorsOpener.localizer();
+    }
 
-	/**
-	 * Indicates if the key would open the door under the current circumstances.
-	 *
-	 * @param player       player which should be checked. Is null if the condition is {@link Scope#WORLD}
-	 * @param world        world of the door
-	 * @param door         door data
-	 * @param currentState the current state of the door.
-	 *
-	 * @return true if the key settings are matched.
-	 */
-	Boolean isOpen(@Nullable Player player, @NotNull World world, @NotNull ConditionalDoor door, @NotNull boolean currentState);
+    /**
+     * Indicates if the key would open the door under the current circumstances.
+     *
+     * @param player       player which should be checked. Is null if the condition is {@link Scope#WORLD}
+     * @param world        world of the door
+     * @param door         door data
+     * @param currentState the current state of the door.
+     *
+     * @return true if the key settings are matched.
+     */
+    Boolean isOpen(@Nullable Player player, @NotNull World world, @NotNull ConditionalDoor door, @NotNull boolean currentState);
 
-	/**
-	 * Get the description of the door condition.
-	 *
-	 * @param localizer localizer instance for translation
-	 *
-	 * @return text component with description.
-	 */
-	Component getDescription(ILocalizer localizer);
+    /**
+     * Get the description of the door condition.
+     *
+     * @param localizer localizer instance for translation
+     *
+     * @return text component with description.
+     */
+    Component getDescription(ILocalizer localizer);
 
-	/**
-	 * Get the command to set this condition with the current settings.
-	 *
-	 * @param door door of condition
-	 *
-	 * @return creation command as string.
-	 */
-	String getCreationCommand(ConditionalDoor door);
+    /**
+     * Get the command to set this condition with the current settings.
+     *
+     * @param door door of condition
+     *
+     * @return creation command as string.
+     */
+    String getCreationCommand(ConditionalDoor door);
 
-	/**
-	 * Get the command to remove this condition
-	 *
-	 * @param door door of condition
-	 *
-	 * @return creation command as string.
-	 */
-	String getRemoveCommand(ConditionalDoor door);
+    /**
+     * Get the command to remove this condition
+     *
+     * @param door door of condition
+     *
+     * @return creation command as string.
+     */
+    String getRemoveCommand(ConditionalDoor door);
 
-	/**
-	 * This method is called after the check for the door of this condition is done and a new evaluation cycle starts.
-	 * Deletes any internal data in this condition
-	 */
-	default void evaluated() {
-	}
+    /**
+     * This method is called after the check for the door of this condition is done and a new evaluation cycle starts.
+     * Deletes any internal data in this condition
+     */
+    default void evaluated() {
+    }
 
-	DoorCondition clone();
+    DoorCondition clone();
 
-	/**
-	 * This method will be called when a door with this key was opened. Only once. This method will only be called, when
-	 * the {@link ConditionContainer#getScope()} is set to {@link Scope#PLAYER}.
-	 *
-	 * @param player player which opened the door.
-	 */
-	default void opened(Player player) {
-	}
+    /**
+     * This method will be called when a door with this key was opened. Only once. This method will only be called, when
+     * the {@link ConditionContainer#getScope()} is set to {@link Scope#PLAYER}.
+     *
+     * @param player player which opened the door.
+     */
+    default void opened(Player player) {
+    }
 }

--- a/src/main/java/de/eldoria/bigdoorsopener/conditions/item/Item.java
+++ b/src/main/java/de/eldoria/bigdoorsopener/conditions/item/Item.java
@@ -7,13 +7,15 @@ import de.eldoria.eldoutilities.crossversion.ServerVersion;
 import de.eldoria.eldoutilities.crossversion.function.VersionFunction;
 import de.eldoria.eldoutilities.crossversion.functionbuilder.VersionFunctionBuilder;
 import de.eldoria.eldoutilities.localization.ILocalizer;
-import de.eldoria.eldoutilities.localization.Localizer;
 import de.eldoria.eldoutilities.serialization.SerializationUtil;
+import de.eldoria.eldoutilities.utils.ObjUtil;
 import lombok.Getter;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.event.HoverEvent;
 import net.kyori.adventure.text.format.NamedTextColor;
+import org.apache.commons.lang.ObjectUtils;
+import org.bukkit.Material;
 import org.bukkit.command.CommandSender;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Player;
@@ -29,215 +31,215 @@ import java.util.Map;
 
 @Getter
 public abstract class Item implements DoorCondition {
-	private final ItemStack item;
-	private final boolean consumed;
+    private final ItemStack item;
+    private final boolean consumed;
 
-	private final VersionFunction<Player, Boolean> handCheck = VersionFunctionBuilder.functionBuilder(Player.class, Boolean.class)
-			.addVersionFunctionBetween(
-					ServerVersion.MC_1_9, ServerVersion.MC_1_16,
-					p -> hasPlayerItemInMainHand(p) || hasPlayerItemInOffHand(p))
-			.addVersionFunction((p) -> {
-				ItemStack item = p.getItemInHand();
-				if (item.getAmount() < getItem().getAmount()) {
-					return false;
-				}
-				return item.isSimilar(getItem());
-			}, ServerVersion.MC_1_8).build();
+    private final VersionFunction<Player, Boolean> handCheck = VersionFunctionBuilder.functionBuilder(Player.class, Boolean.class)
+            .addVersionFunctionBetween(
+                    ServerVersion.MC_1_9, ServerVersion.MC_1_16,
+                    p -> hasPlayerItemInMainHand(p) || hasPlayerItemInOffHand(p))
+            .addVersionFunction((p) -> {
+                ItemStack item = p.getItemInHand();
+                if (item.getAmount() < getItem().getAmount()) {
+                    return false;
+                }
+                return item.isSimilar(getItem());
+            }, ServerVersion.MC_1_8).build();
 
-	private final VersionFunction<Player, Boolean> takeFromHand = VersionFunctionBuilder.functionBuilder(Player.class, Boolean.class)
-			.addVersionFunctionBetween(
-					ServerVersion.MC_1_9, ServerVersion.MC_1_16,
-					(p) -> {
-						if (hasPlayerItemInMainHand(p)) {
-							takeFromMainHand(p);
-							return true;
-						} else if (hasPlayerItemInOffHand(p)) {
-							takeFromOffHand(p);
-							return true;
-						}
-						return false;
-					}).addVersionFunction(
-					p -> {
-						if (handCheck.apply(p)) {
-							ItemStack item = p.getItemInHand();
-							item.setAmount(item.getAmount() - getItem().getAmount());
-							p.setItemInHand(item);
-							p.updateInventory();
-							return true;
-						}
-						return false;
-					}, ServerVersion.MC_1_8).build();
+    private final VersionFunction<Player, Boolean> takeFromHand = VersionFunctionBuilder.functionBuilder(Player.class, Boolean.class)
+            .addVersionFunctionBetween(
+                    ServerVersion.MC_1_9, ServerVersion.MC_1_16,
+                    (p) -> {
+                        if (hasPlayerItemInMainHand(p)) {
+                            takeFromMainHand(p);
+                            return true;
+                        } else if (hasPlayerItemInOffHand(p)) {
+                            takeFromOffHand(p);
+                            return true;
+                        }
+                        return false;
+                    }).addVersionFunction(
+                    p -> {
+                        if (handCheck.apply(p)) {
+                            ItemStack item = p.getItemInHand();
+                            item.setAmount(item.getAmount() - getItem().getAmount());
+                            p.setItemInHand(item);
+                            p.updateInventory();
+                            return true;
+                        }
+                        return false;
+                    }, ServerVersion.MC_1_8).build();
 
-	/**
-	 * Creates a new item key
-	 *
-	 * @param item     item stack which defines the item needed to open the door. amount matters.
-	 * @param consumed true if the items are consumed when the door is opened
-	 */
-	public Item(ItemStack item, boolean consumed) {
-		this.item = item;
-		this.consumed = consumed;
-	}
+    /**
+     * Creates a new item key
+     *
+     * @param item     item stack which defines the item needed to open the door. amount matters.
+     * @param consumed true if the items are consumed when the door is opened
+     */
+    public Item(ItemStack item, boolean consumed) {
+        this.item = ObjUtil.nonNull(item, new ItemStack(Material.AIR));
+        this.consumed = consumed;
+    }
 
-	public static List<String> onTabComplete(CommandSender sender, ILocalizer localizer, String[] args) {
-		if (args.length == 1) {
-			return Collections.singletonList("<" + localizer.getMessage("syntax.amount") + ">");
-		}
-		if (args.length == 2) {
-			if (args[1].isEmpty()) {
-				return Arrays.asList("true", "false");
-			}
-			return Arrays.asList("[" + localizer.getMessage("tabcomplete.consumed") + "]", "true", "false");
-		}
-		return Collections.emptyList();
-	}
+    public static List<String> onTabComplete(CommandSender sender, ILocalizer localizer, String[] args) {
+        if (args.length == 1) {
+            return Collections.singletonList("<" + localizer.getMessage("syntax.amount") + ">");
+        }
+        if (args.length == 2) {
+            if (args[1].isEmpty()) {
+                return Arrays.asList("true", "false");
+            }
+            return Arrays.asList("[" + localizer.getMessage("tabcomplete.consumed") + "]", "true", "false");
+        }
+        return Collections.emptyList();
+    }
 
-	/**
-	 * This method will be called when a door with this key was opened. Only once.
-	 *
-	 * @param player player which opened the door.
-	 */
-	@Override
-	public abstract void opened(Player player);
+    /**
+     * This method will be called when a door with this key was opened. Only once.
+     *
+     * @param player player which opened the door.
+     */
+    @Override
+    public abstract void opened(Player player);
 
-	/**
-	 * Checks if a player has a item in the off or main hand.
-	 *
-	 * @param player player to check
-	 *
-	 * @return true if the player has the item in one of his hands.
-	 */
-	protected boolean hasPlayerItemInHand(Player player) {
-		return handCheck.apply(player);
-	}
+    /**
+     * Checks if a player has a item in the off or main hand.
+     *
+     * @param player player to check
+     *
+     * @return true if the player has the item in one of his hands.
+     */
+    protected boolean hasPlayerItemInHand(Player player) {
+        return handCheck.apply(player);
+    }
 
-	/**
-	 * Checks if a player has a item in the main hand.
-	 *
-	 * @param player player to check
-	 *
-	 * @return true if the player has the item in his main hand.
-	 */
-	private boolean hasPlayerItemInMainHand(Player player) {
-		ItemStack item = player.getInventory().getItemInMainHand();
-		if (item.getAmount() < getItem().getAmount()) {
-			return false;
-		}
-		return item.isSimilar(getItem());
-	}
+    /**
+     * Checks if a player has a item in the main hand.
+     *
+     * @param player player to check
+     *
+     * @return true if the player has the item in his main hand.
+     */
+    private boolean hasPlayerItemInMainHand(Player player) {
+        ItemStack item = player.getInventory().getItemInMainHand();
+        if (item.getAmount() < this.item.getAmount()) {
+            return false;
+        }
+        return item.isSimilar(getItem());
+    }
 
-	/**
-	 * Checks if a player has a item in the off hand.
-	 *
-	 * @param player player to check
-	 *
-	 * @return true if the player has the item in his main hands.
-	 */
-	private boolean hasPlayerItemInOffHand(Player player) {
-		ItemStack item = player.getInventory().getItemInOffHand();
-		if (item.getAmount() < getItem().getAmount()) {
-			return false;
-		}
-		return item.isSimilar(getItem());
-	}
+    /**
+     * Checks if a player has a item in the off hand.
+     *
+     * @param player player to check
+     *
+     * @return true if the player has the item in his main hands.
+     */
+    private boolean hasPlayerItemInOffHand(Player player) {
+        ItemStack item = player.getInventory().getItemInOffHand();
+        if (item.getAmount() < getItem().getAmount()) {
+            return false;
+        }
+        return item.isSimilar(getItem());
+    }
 
-	/**
-	 * Checks if a player has a item in his inventory.
-	 *
-	 * @param player player to check
-	 *
-	 * @return true if the player has the item in his inventory.
-	 */
-	protected boolean hasPlayerItemInInventory(Player player) {
-		PlayerInventory inventory = player.getInventory();
-		return inventory.containsAtLeast(getItem(), getItem().getAmount());
-	}
+    /**
+     * Checks if a player has a item in his inventory.
+     *
+     * @param player player to check
+     *
+     * @return true if the player has the item in his inventory.
+     */
+    protected boolean hasPlayerItemInInventory(Player player) {
+        PlayerInventory inventory = player.getInventory();
+        return inventory.containsAtLeast(getItem(), getItem().getAmount());
+    }
 
-	/**
-	 * Takes the item from the off hand.
-	 *
-	 * @param player player to take items from
-	 */
-	private void takeFromOffHand(Player player) {
-		ItemStack item = player.getInventory().getItemInMainHand();
-		item.setAmount(item.getAmount() - getItem().getAmount());
-		player.getInventory().setItemInMainHand(item);
-		player.updateInventory();
-	}
+    /**
+     * Takes the item from the off hand.
+     *
+     * @param player player to take items from
+     */
+    private void takeFromOffHand(Player player) {
+        ItemStack item = player.getInventory().getItemInMainHand();
+        item.setAmount(item.getAmount() - getItem().getAmount());
+        player.getInventory().setItemInMainHand(item);
+        player.updateInventory();
+    }
 
-	/**
-	 * Takes the item from the main hand.
-	 *
-	 * @param player player to take items from
-	 */
-	private void takeFromMainHand(Player player) {
-		ItemStack item = player.getInventory().getItemInMainHand();
-		item.setAmount(item.getAmount() - getItem().getAmount());
-		player.getInventory().setItemInMainHand(item);
-		player.updateInventory();
-	}
+    /**
+     * Takes the item from the main hand.
+     *
+     * @param player player to take items from
+     */
+    private void takeFromMainHand(Player player) {
+        ItemStack item = player.getInventory().getItemInMainHand();
+        item.setAmount(item.getAmount() - getItem().getAmount());
+        player.getInventory().setItemInMainHand(item);
+        player.updateInventory();
+    }
 
-	/**
-	 * Takes the item from the inventory.
-	 *
-	 * @param player player to take items from
-	 */
-	protected void takeFromInventory(Player player) {
-		player.getInventory().removeItem(getItem());
-		player.updateInventory();
-	}
+    /**
+     * Takes the item from the inventory.
+     *
+     * @param player player to take items from
+     */
+    protected void takeFromInventory(Player player) {
+        player.getInventory().removeItem(getItem());
+        player.updateInventory();
+    }
 
-	/**
-	 * Takes the item from the main or off hand.
-	 *
-	 * @param player player to take items from
-	 */
-	protected boolean tryTakeFromHands(Player player) {
-		return takeFromHand.apply(player);
-	}
+    /**
+     * Takes the item from the main or off hand.
+     *
+     * @param player player to take items from
+     */
+    protected boolean tryTakeFromHands(Player player) {
+        return takeFromHand.apply(player);
+    }
 
-	@Override
-	public @NotNull Map<String, Object> serialize() {
-		return SerializationUtil.newBuilder()
-				.add("item", item)
-				.add("consumed", consumed)
-				.build();
-	}
+    @Override
+    public @NotNull Map<String, Object> serialize() {
+        return SerializationUtil.newBuilder()
+                .add("item", item)
+                .add("consumed", consumed)
+                .build();
+    }
 
-	@Override
-	public Component getDescription(ILocalizer localizer) {
-		ItemMeta meta = item.getItemMeta();
-		TextComponent.Builder builder = Component.text();
-		if (meta != null) {
-			builder.append(Component.text(meta.getDisplayName(), NamedTextColor.AQUA));
-			if (meta.getLore() != null) {
-				for (String s : meta.getLore()) {
-					builder.append(Component.newline())
-							.append(Component.text(s, NamedTextColor.LIGHT_PURPLE));
-				}
-			}
-			for (Map.Entry<Enchantment, Integer> entry : meta.getEnchants().entrySet()) {
-				builder.append(Component.newline())
-						.append(Component.text(entry.getKey().getKey().getKey() + " "
-								+ entry.getValue().toString(), NamedTextColor.GRAY));
-			}
-		}
+    @Override
+    public Component getDescription(ILocalizer localizer) {
+        ItemMeta meta = item.getItemMeta();
+        TextComponent.Builder builder = Component.text();
+        if (meta != null) {
+            builder.append(Component.text(meta.getDisplayName(), NamedTextColor.AQUA));
+            if (meta.getLore() != null) {
+                for (String s : meta.getLore()) {
+                    builder.append(Component.newline())
+                            .append(Component.text(s, NamedTextColor.LIGHT_PURPLE));
+                }
+            }
+            for (Map.Entry<Enchantment, Integer> entry : meta.getEnchants().entrySet()) {
+                builder.append(Component.newline())
+                        .append(Component.text(entry.getKey().getKey().getKey() + " "
+                                + entry.getValue().toString(), NamedTextColor.GRAY));
+            }
+        }
 
-		return Component.text()
-				.append(Component.text(localizer.getMessage("conditionDesc.item") + " ", C.baseColor))
-				.append(Component.text("[" + item.getType().name().toLowerCase() + "] x" + item.getAmount(), C.highlightColor)
-						.hoverEvent(HoverEvent.showText(builder.build())))
-				.append(Component.newline())
-				.append(Component.text(localizer.getMessage("conditionDesc.consumed") + " ", C.baseColor))
-				.append(Component.text(Boolean.toString(isConsumed()), C.highlightColor))
-				.build();
-	}
+        return Component.text()
+                .append(Component.text(localizer.getMessage("conditionDesc.item") + " ", C.baseColor))
+                .append(Component.text("[" + item.getType().name().toLowerCase() + "] x" + item.getAmount(), C.highlightColor)
+                        .hoverEvent(HoverEvent.showText(builder.build())))
+                .append(Component.newline())
+                .append(Component.text(localizer.getMessage("conditionDesc.consumed") + " ", C.baseColor))
+                .append(Component.text(Boolean.toString(isConsumed()), C.highlightColor))
+                .build();
+    }
 
-	@Override
-	public String getRemoveCommand(ConditionalDoor door) {
-		return REMOVE_COMMAND + door.getDoorUID() + " item";
-	}
+    @Override
+    public String getRemoveCommand(ConditionalDoor door) {
+        return REMOVE_COMMAND + door.getDoorUID() + " item";
+    }
 
-	@Override
-	public abstract Item clone();
+    @Override
+    public abstract Item clone();
 }

--- a/src/main/java/de/eldoria/bigdoorsopener/conditions/item/ItemConditionListener.java
+++ b/src/main/java/de/eldoria/bigdoorsopener/conditions/item/ItemConditionListener.java
@@ -4,13 +4,12 @@ import de.eldoria.bigdoorsopener.conditions.DoorCondition;
 import de.eldoria.bigdoorsopener.conditions.item.interacting.ItemInteraction;
 import de.eldoria.bigdoorsopener.config.Config;
 import de.eldoria.bigdoorsopener.core.adapter.BigDoorsAdapter;
-import de.eldoria.eldoutilities.localization.Localizer;
 import nl.pim16aap2.bigDoors.BigDoors;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerInteractEvent;
 
-import java.util.Optional;
+import java.util.List;
 
 /**
  * This listener controls when a player tries to open a door with a item.
@@ -27,10 +26,12 @@ public class ItemConditionListener extends BigDoorsAdapter implements Listener {
     public void onItemInteract(PlayerInteractEvent event) {
         config.getDoors().forEach(d -> {
             if (!d.isEnabled()) return;
-            Optional<DoorCondition> item = d.getConditionBag().getCondition("item");
-            if ((!item.isPresent())) return;
-            if (item.get() instanceof ItemInteraction) {
-                ((ItemInteraction) item.get()).clicked(event, isAvailableToOpen(d));
+            List<DoorCondition> items = d.getConditionBag().getConditions("item");
+            if ((items.isEmpty())) return;
+            for (DoorCondition item : items) {
+                if (item instanceof ItemInteraction) {
+                    ((ItemInteraction) item).clicked(event, isAvailableToOpen(d));
+                }
             }
         });
     }

--- a/src/main/java/de/eldoria/bigdoorsopener/conditions/item/ItemHolding.java
+++ b/src/main/java/de/eldoria/bigdoorsopener/conditions/item/ItemHolding.java
@@ -6,7 +6,6 @@ import de.eldoria.bigdoorsopener.core.conditions.ConditionRegistrar;
 import de.eldoria.bigdoorsopener.core.conditions.Scope;
 import de.eldoria.bigdoorsopener.door.ConditionalDoor;
 import de.eldoria.eldoutilities.localization.ILocalizer;
-import de.eldoria.eldoutilities.localization.Localizer;
 import de.eldoria.eldoutilities.localization.Replacement;
 import de.eldoria.eldoutilities.serialization.SerializationUtil;
 import de.eldoria.eldoutilities.serialization.TypeResolvingMap;
@@ -81,7 +80,7 @@ public class ItemHolding extends Item {
                     ItemStack itemInMainHand = player.getInventory().getItemInMainHand().clone();
 
                     itemInMainHand.setAmount(amount.getAsInt());
-                    conditionBag.putCondition(new ItemHolding(itemInMainHand, consume.get()));
+                    conditionBag.accept(new ItemHolding(itemInMainHand, consume.get()));
                     messageSender.sendMessage(player, localizer.getMessage("setCondition.itemHolding"));
 
                 })

--- a/src/main/java/de/eldoria/bigdoorsopener/conditions/item/ItemOwning.java
+++ b/src/main/java/de/eldoria/bigdoorsopener/conditions/item/ItemOwning.java
@@ -6,7 +6,6 @@ import de.eldoria.bigdoorsopener.core.conditions.ConditionRegistrar;
 import de.eldoria.bigdoorsopener.core.conditions.Scope;
 import de.eldoria.bigdoorsopener.door.ConditionalDoor;
 import de.eldoria.eldoutilities.localization.ILocalizer;
-import de.eldoria.eldoutilities.localization.Localizer;
 import de.eldoria.eldoutilities.localization.Replacement;
 import de.eldoria.eldoutilities.serialization.SerializationUtil;
 import de.eldoria.eldoutilities.serialization.TypeResolvingMap;
@@ -74,7 +73,7 @@ public class ItemOwning extends Item {
                     ItemStack itemInMainHand = player.getInventory().getItemInMainHand().clone();
 
                     itemInMainHand.setAmount(amount.getAsInt());
-                    conditionBag.putCondition(new ItemOwning(itemInMainHand, consume.get()));
+                    conditionBag.accept(new ItemOwning(itemInMainHand, consume.get()));
                     messageSender.sendMessage(player, localizer.getMessage("setCondition.itemOwning"));
                 })
                 .onTabComplete(Item::onTabComplete)

--- a/src/main/java/de/eldoria/bigdoorsopener/conditions/item/interacting/ItemBlock.java
+++ b/src/main/java/de/eldoria/bigdoorsopener/conditions/item/interacting/ItemBlock.java
@@ -9,7 +9,6 @@ import de.eldoria.bigdoorsopener.core.listener.registration.RegisterInteraction;
 import de.eldoria.bigdoorsopener.door.ConditionalDoor;
 import de.eldoria.bigdoorsopener.util.C;
 import de.eldoria.eldoutilities.localization.ILocalizer;
-import de.eldoria.eldoutilities.localization.Localizer;
 import de.eldoria.eldoutilities.localization.Replacement;
 import de.eldoria.eldoutilities.serialization.SerializationUtil;
 import de.eldoria.eldoutilities.serialization.TypeResolvingMap;
@@ -124,7 +123,7 @@ public class ItemBlock extends ItemInteraction {
                         if (event.getClickedBlock() == null) return false;
                         BlockVector blockVector = event.getClickedBlock().getLocation().toVector().toBlockVector();
                         itemBlock.setPosition(blockVector);
-                        conditionBag.putCondition(itemBlock);
+                        conditionBag.accept(itemBlock);
                         event.setCancelled(true);
                         mSender.sendMessage(player, localizer.getMessage("setCondition.itemBlockRegistered"));
                         return true;

--- a/src/main/java/de/eldoria/bigdoorsopener/conditions/item/interacting/ItemClick.java
+++ b/src/main/java/de/eldoria/bigdoorsopener/conditions/item/interacting/ItemClick.java
@@ -7,7 +7,6 @@ import de.eldoria.bigdoorsopener.core.conditions.ConditionRegistrar;
 import de.eldoria.bigdoorsopener.core.conditions.Scope;
 import de.eldoria.bigdoorsopener.door.ConditionalDoor;
 import de.eldoria.eldoutilities.localization.ILocalizer;
-import de.eldoria.eldoutilities.localization.Localizer;
 import de.eldoria.eldoutilities.localization.Replacement;
 import de.eldoria.eldoutilities.serialization.SerializationUtil;
 import de.eldoria.eldoutilities.serialization.TypeResolvingMap;
@@ -82,7 +81,7 @@ public class ItemClick extends ItemInteraction {
                     ItemStack itemInMainHand = player.getInventory().getItemInMainHand().clone();
 
                     itemInMainHand.setAmount(amount.getAsInt());
-                    conditionBag.putCondition(new ItemClick(itemInMainHand, consume.get()));
+                    conditionBag.accept(new ItemClick(itemInMainHand, consume.get()));
                     messageSender.sendMessage(player, localizer.getMessage("setCondition.itemClick"));
                 })
                 .onTabComplete(Item::onTabComplete)

--- a/src/main/java/de/eldoria/bigdoorsopener/conditions/location/Proximity.java
+++ b/src/main/java/de/eldoria/bigdoorsopener/conditions/location/Proximity.java
@@ -8,7 +8,6 @@ import de.eldoria.bigdoorsopener.door.ConditionalDoor;
 import de.eldoria.bigdoorsopener.util.C;
 import de.eldoria.eldoutilities.functions.TriFunction;
 import de.eldoria.eldoutilities.localization.ILocalizer;
-import de.eldoria.eldoutilities.localization.Localizer;
 import de.eldoria.eldoutilities.localization.Replacement;
 import de.eldoria.eldoutilities.serialization.SerializationUtil;
 import de.eldoria.eldoutilities.serialization.TypeResolvingMap;
@@ -109,7 +108,7 @@ public class Proximity implements Location {
                         return;
                     }
 
-                    conditionBag.putCondition(new Proximity(vector, form));
+                    conditionBag.accept(new Proximity(vector, form));
 
                     // TODO: display region Maybe some day. In a far future...
 

--- a/src/main/java/de/eldoria/bigdoorsopener/conditions/location/Region.java
+++ b/src/main/java/de/eldoria/bigdoorsopener/conditions/location/Region.java
@@ -12,7 +12,6 @@ import de.eldoria.bigdoorsopener.core.conditions.Scope;
 import de.eldoria.bigdoorsopener.door.ConditionalDoor;
 import de.eldoria.bigdoorsopener.util.C;
 import de.eldoria.eldoutilities.localization.ILocalizer;
-import de.eldoria.eldoutilities.localization.Localizer;
 import de.eldoria.eldoutilities.localization.Replacement;
 import de.eldoria.eldoutilities.serialization.SerializationUtil;
 import de.eldoria.eldoutilities.serialization.TypeResolvingMap;
@@ -107,7 +106,7 @@ public class Region implements Location {
                         messageSender.sendError(player, localizer.getMessage("error.regionNotFound"));
                         return;
                     }
-                    conditionBag.putCondition(new Region(region, player.getWorld()));
+                    conditionBag.accept(new Region(region, player.getWorld()));
                     messageSender.sendMessage(player, localizer.getMessage("setCondition.region"));
 
                 })

--- a/src/main/java/de/eldoria/bigdoorsopener/conditions/location/SimpleRegion.java
+++ b/src/main/java/de/eldoria/bigdoorsopener/conditions/location/SimpleRegion.java
@@ -10,7 +10,6 @@ import de.eldoria.bigdoorsopener.core.listener.registration.RegisterInteraction;
 import de.eldoria.bigdoorsopener.door.ConditionalDoor;
 import de.eldoria.bigdoorsopener.util.C;
 import de.eldoria.eldoutilities.localization.ILocalizer;
-import de.eldoria.eldoutilities.localization.Localizer;
 import de.eldoria.eldoutilities.localization.Replacement;
 import de.eldoria.eldoutilities.messages.MessageSender;
 import de.eldoria.eldoutilities.serialization.SerializationUtil;
@@ -76,7 +75,7 @@ public class SimpleRegion implements Location {
                                 messageSender.sendMessage(player, localizer.getMessage("setCondition.secondPoint"));
                                 return false;
                             }
-                            conditionBag.putCondition(new SimpleRegion(first, vec, world));
+                            conditionBag.accept(new SimpleRegion(first, vec, world));
                             event.setCancelled(true);
                             messageSender.sendMessage(player, localizer.getMessage("setCondition.simpleRegionRegisterd"));
                             return true;
@@ -97,7 +96,6 @@ public class SimpleRegion implements Location {
                 if (pos.getX() > maximum.getX() || pos.getX() < minimum.getX()) return false;
                 if (pos.getY() > maximum.getY() || pos.getY() < minimum.getY()) return false;
                 return !(pos.getZ() > maximum.getZ()) && !(pos.getZ() < minimum.getZ());
-
             });
         } catch (ExecutionException e) {
             BigDoorsOpener.logger().log(Level.WARNING, "Could not compute value", e);

--- a/src/main/java/de/eldoria/bigdoorsopener/conditions/permission/DoorPermission.java
+++ b/src/main/java/de/eldoria/bigdoorsopener/conditions/permission/DoorPermission.java
@@ -9,7 +9,6 @@ import de.eldoria.bigdoorsopener.core.conditions.Scope;
 import de.eldoria.bigdoorsopener.door.ConditionalDoor;
 import de.eldoria.bigdoorsopener.util.C;
 import de.eldoria.eldoutilities.localization.ILocalizer;
-import de.eldoria.eldoutilities.localization.Localizer;
 import de.eldoria.eldoutilities.localization.Replacement;
 import de.eldoria.eldoutilities.serialization.SerializationUtil;
 import de.eldoria.eldoutilities.serialization.TypeResolvingMap;
@@ -81,7 +80,7 @@ public class DoorPermission extends BigDoorsAdapter implements Permission {
                         messageSender.sendError(player, localizer.getMessage("error.invalidAccessLevel"));
                         return;
                     }
-                    conditionBag.putCondition(new DoorPermission(i));
+                    conditionBag.accept(new DoorPermission(i));
                     messageSender.sendMessage(player, localizer.getMessage("setCondition.doorPermission"));
 
                 })

--- a/src/main/java/de/eldoria/bigdoorsopener/conditions/permission/PermissionNode.java
+++ b/src/main/java/de/eldoria/bigdoorsopener/conditions/permission/PermissionNode.java
@@ -7,7 +7,6 @@ import de.eldoria.bigdoorsopener.core.conditions.Scope;
 import de.eldoria.bigdoorsopener.door.ConditionalDoor;
 import de.eldoria.bigdoorsopener.util.C;
 import de.eldoria.eldoutilities.localization.ILocalizer;
-import de.eldoria.eldoutilities.localization.Localizer;
 import de.eldoria.eldoutilities.localization.Replacement;
 import de.eldoria.eldoutilities.serialization.SerializationUtil;
 import de.eldoria.eldoutilities.serialization.TypeResolvingMap;
@@ -52,7 +51,7 @@ public class PermissionNode implements Permission {
                         return;
                     }
 
-                    conditionBag.putCondition(new PermissionNode(arguments[0]));
+                    conditionBag.accept(new PermissionNode(arguments[0]));
                     messageSender.sendMessage(player, localizer.getMessage("setCondition.permissionNode"));
 
                 })

--- a/src/main/java/de/eldoria/bigdoorsopener/conditions/standalone/Placeholder.java
+++ b/src/main/java/de/eldoria/bigdoorsopener/conditions/standalone/Placeholder.java
@@ -10,7 +10,6 @@ import de.eldoria.bigdoorsopener.util.C;
 import de.eldoria.bigdoorsopener.util.JsSyntaxHelper;
 import de.eldoria.eldoutilities.container.Pair;
 import de.eldoria.eldoutilities.localization.ILocalizer;
-import de.eldoria.eldoutilities.localization.Localizer;
 import de.eldoria.eldoutilities.localization.Replacement;
 import de.eldoria.eldoutilities.serialization.SerializationUtil;
 import de.eldoria.eldoutilities.serialization.TypeResolvingMap;
@@ -95,7 +94,7 @@ public class Placeholder implements DoorCondition {
                                     Replacement.create("ERROR", result.second).addFormatting('6')));
                             return;
                         case FINE:
-                            conditionBag.putCondition(new Placeholder(JsSyntaxHelper.translateEvaluator(evaluator)));
+                            conditionBag.accept(new Placeholder(JsSyntaxHelper.translateEvaluator(evaluator)));
                             break;
                     }
 

--- a/src/main/java/de/eldoria/bigdoorsopener/conditions/standalone/Time.java
+++ b/src/main/java/de/eldoria/bigdoorsopener/conditions/standalone/Time.java
@@ -10,7 +10,6 @@ import de.eldoria.bigdoorsopener.core.conditions.Scope;
 import de.eldoria.bigdoorsopener.door.ConditionalDoor;
 import de.eldoria.bigdoorsopener.util.C;
 import de.eldoria.eldoutilities.localization.ILocalizer;
-import de.eldoria.eldoutilities.localization.Localizer;
 import de.eldoria.eldoutilities.localization.Replacement;
 import de.eldoria.eldoutilities.serialization.SerializationUtil;
 import de.eldoria.eldoutilities.serialization.TypeResolvingMap;
@@ -121,7 +120,7 @@ public class Time implements DoorCondition {
                         messageSender.sendError(player, localizer.getMessage("error.invalidBoolean"));
                         return;
                     }
-                    conditionBag.putCondition(new Time(open.getAsInt(), close.getAsInt(), force.get()));
+                    conditionBag.accept(new Time(open.getAsInt(), close.getAsInt(), force.get()));
                     messageSender.sendMessage(player, localizer.getMessage("setCondition.time",
                             Replacement.create("OPEN", Parser.parseTicksToTime(open.getAsInt())),
                             Replacement.create("CLOSE", Parser.parseTicksToTime(close.getAsInt()))));

--- a/src/main/java/de/eldoria/bigdoorsopener/conditions/standalone/mythicmobs/MythicMob.java
+++ b/src/main/java/de/eldoria/bigdoorsopener/conditions/standalone/mythicmobs/MythicMob.java
@@ -8,7 +8,6 @@ import de.eldoria.bigdoorsopener.core.conditions.Scope;
 import de.eldoria.bigdoorsopener.door.ConditionalDoor;
 import de.eldoria.bigdoorsopener.util.C;
 import de.eldoria.eldoutilities.localization.ILocalizer;
-import de.eldoria.eldoutilities.localization.Localizer;
 import de.eldoria.eldoutilities.localization.Replacement;
 import de.eldoria.eldoutilities.serialization.SerializationUtil;
 import de.eldoria.eldoutilities.utils.ArrayUtil;
@@ -69,7 +68,7 @@ public class MythicMob implements DoorCondition {
 						return;
 					}
 
-					conditionBag.putCondition(new MythicMob(mob));
+					conditionBag.accept(new MythicMob(mob));
 					messageSender.sendMessage(player, localizer().getMessage("setCondition.mythicMob"));
 
 				})

--- a/src/main/java/de/eldoria/bigdoorsopener/conditions/standalone/mythicmobs/MythicMobsListener.java
+++ b/src/main/java/de/eldoria/bigdoorsopener/conditions/standalone/mythicmobs/MythicMobsListener.java
@@ -3,13 +3,12 @@ package de.eldoria.bigdoorsopener.conditions.standalone.mythicmobs;
 import de.eldoria.bigdoorsopener.conditions.DoorCondition;
 import de.eldoria.bigdoorsopener.config.Config;
 import de.eldoria.bigdoorsopener.core.adapter.BigDoorsAdapter;
-import de.eldoria.eldoutilities.localization.Localizer;
 import io.lumine.xikage.mythicmobs.api.bukkit.events.MythicMobDeathEvent;
 import nl.pim16aap2.bigDoors.BigDoors;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 
-import java.util.Optional;
+import java.util.List;
 
 public class MythicMobsListener extends BigDoorsAdapter implements Listener {
 
@@ -23,9 +22,9 @@ public class MythicMobsListener extends BigDoorsAdapter implements Listener {
     @EventHandler
     public void onMobDeath(MythicMobDeathEvent event) {
         config.getDoors().forEach(d -> {
-            Optional<DoorCondition> mythicMob = d.getConditionBag().getCondition("mythicMob");
-            if (!mythicMob.isPresent()) return;
-            ((MythicMob) mythicMob.get()).killed(event, isAvailableToOpen(d));
+            List<DoorCondition> mythicMobs = d.getConditionBag().getConditions("mythicMob");
+            if (mythicMobs.isEmpty()) return;
+            mythicMobs.forEach(m -> ((MythicMob) m).killed(event, isAvailableToOpen(d)));
         });
     }
 }

--- a/src/main/java/de/eldoria/bigdoorsopener/conditions/standalone/weather/Weather.java
+++ b/src/main/java/de/eldoria/bigdoorsopener/conditions/standalone/weather/Weather.java
@@ -10,7 +10,6 @@ import de.eldoria.bigdoorsopener.core.conditions.Scope;
 import de.eldoria.bigdoorsopener.door.ConditionalDoor;
 import de.eldoria.bigdoorsopener.util.C;
 import de.eldoria.eldoutilities.localization.ILocalizer;
-import de.eldoria.eldoutilities.localization.Localizer;
 import de.eldoria.eldoutilities.localization.Replacement;
 import de.eldoria.eldoutilities.serialization.SerializationUtil;
 import de.eldoria.eldoutilities.serialization.TypeResolvingMap;
@@ -89,7 +88,7 @@ public class Weather implements DoorCondition {
                         return;
                     }
 
-                    conditionBag.putCondition(new Weather(weatherType, forceWeather.get()));
+                    conditionBag.accept(new Weather(weatherType, forceWeather.get()));
                     messageSender.sendMessage(player, localizer.getMessage("setCondition.weather",
                             Replacement.create("OPEN", weatherType == WeatherType.CLEAR
                                     ? localizer.getMessage("conditionDesc.clear")

--- a/src/main/java/de/eldoria/bigdoorsopener/conditions/worldlocation/WorldLocation.java
+++ b/src/main/java/de/eldoria/bigdoorsopener/conditions/worldlocation/WorldLocation.java
@@ -1,0 +1,14 @@
+package de.eldoria.bigdoorsopener.conditions.worldlocation;
+
+import de.eldoria.bigdoorsopener.conditions.DoorCondition;
+import de.eldoria.bigdoorsopener.door.ConditionalDoor;
+
+public interface WorldLocation extends DoorCondition {
+    @Override
+    default String getRemoveCommand(ConditionalDoor door) {
+        return REMOVE_COMMAND + door.getDoorUID() + " worldlocation";
+    }
+
+    @Override
+    WorldLocation clone();
+}

--- a/src/main/java/de/eldoria/bigdoorsopener/conditions/worldlocation/WorldProximity.java
+++ b/src/main/java/de/eldoria/bigdoorsopener/conditions/worldlocation/WorldProximity.java
@@ -1,0 +1,213 @@
+package de.eldoria.bigdoorsopener.conditions.worldlocation;
+
+import de.eldoria.bigdoorsopener.core.BigDoorsOpener;
+import de.eldoria.bigdoorsopener.core.conditions.ConditionContainer;
+import de.eldoria.bigdoorsopener.core.conditions.ConditionRegistrar;
+import de.eldoria.bigdoorsopener.core.conditions.Scope;
+import de.eldoria.bigdoorsopener.door.ConditionalDoor;
+import de.eldoria.bigdoorsopener.util.C;
+import de.eldoria.eldoutilities.functions.TriFunction;
+import de.eldoria.eldoutilities.localization.ILocalizer;
+import de.eldoria.eldoutilities.localization.Replacement;
+import de.eldoria.eldoutilities.serialization.SerializationUtil;
+import de.eldoria.eldoutilities.serialization.TypeResolvingMap;
+import de.eldoria.eldoutilities.utils.ArgumentUtils;
+import de.eldoria.eldoutilities.utils.ArrayUtil;
+import de.eldoria.eldoutilities.utils.EnumUtil;
+import de.eldoria.eldoutilities.utils.Parser;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.World;
+import org.bukkit.configuration.serialization.SerializableAs;
+import org.bukkit.entity.Player;
+import org.bukkit.util.Vector;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalDouble;
+import java.util.stream.Collectors;
+
+import static de.eldoria.bigdoorsopener.commands.CommandHelper.argumentsInvalid;
+
+/**
+ * A condition which opens the door when the player is within a specific range of defined by geometric form
+ */
+@SerializableAs("worldProximityCondition")
+public class WorldProximity implements WorldLocation {
+    private final Vector dimensions;
+    private final ProximityForm proximityForm;
+
+    public WorldProximity(Vector dimensions, ProximityForm proximityForm) {
+        this.dimensions = dimensions;
+        this.proximityForm = proximityForm;
+    }
+
+    public WorldProximity(Map<String, Object> map) {
+        TypeResolvingMap resolvingMap = SerializationUtil.mapOf(map);
+        dimensions = resolvingMap.getValue("dimensions");
+        String formString = resolvingMap.getValue("proximityForm");
+        formString = formString.replaceAll("(?i)elipsoid", "ellipsoid");
+        proximityForm = EnumUtil.parse(formString, ProximityForm.class);
+    }
+
+    public static ConditionContainer getConditionContainer() {
+        return ConditionContainer.ofClass(WorldProximity.class, Scope.WORLD)
+                .withFactory((player, messageSender, conditionBag, arguments) -> {
+                    ILocalizer localizer = BigDoorsOpener.localizer();
+                    if (argumentsInvalid(player, messageSender, localizer, arguments, 1,
+                            "<" + localizer.getMessage("syntax.doorId") + "> <"
+                                    + localizer.getMessage("syntax.condition") + "> <"
+                                    + localizer.getMessage("tabcomplete.dimensions") + "> ["
+                                    + localizer.getMessage("syntax.proximityForm") + "]")) {
+                        return;
+                    }
+
+                    Vector vector;
+                    String[] coords = arguments[0].split(",");
+
+                    // parse the size.
+                    if (coords.length == 1) {
+                        OptionalDouble size = Parser.parseDouble(arguments[0]);
+                        if (!size.isPresent()) {
+                            messageSender.sendError(player, localizer.getMessage("error.invalidNumber"));
+                            return;
+                        }
+                        vector = new Vector(size.getAsDouble(), size.getAsDouble(), size.getAsDouble());
+                    } else if (coords.length == 3) {
+                        OptionalDouble x = Parser.parseDouble(coords[0]);
+                        OptionalDouble y = Parser.parseDouble(coords[1]);
+                        OptionalDouble z = Parser.parseDouble(coords[2]);
+                        if (x.isPresent() && y.isPresent() && z.isPresent()) {
+                            vector = new Vector(x.getAsDouble(), y.getAsDouble(), z.getAsDouble());
+                        } else {
+                            messageSender.sendError(player, localizer.getMessage("error.invalidNumber"));
+                            return;
+                        }
+                    } else {
+                        messageSender.sendError(player, localizer.getMessage("error.invalidVector"));
+                        return;
+                    }
+
+                    // check if vector is inside bounds.
+                    if (vector.getX() < 1 || vector.getX() > 100
+                            || vector.getY() < 1 || vector.getY() > 100
+                            || vector.getZ() < 1 || vector.getZ() > 100) {
+                        messageSender.sendError(player, localizer.getMessage("error.invalidRange",
+                                Replacement.create("MIN", 1).addFormatting('6'),
+                                Replacement.create("MAX", 100).addFormatting('6')));
+                        return;
+                    }
+
+                    WorldProximity.ProximityForm form = ArgumentUtils.getOptionalParameter(arguments, 1, WorldProximity.ProximityForm.CUBOID, (s) -> EnumUtil.parse(s, WorldProximity.ProximityForm.class));
+
+                    if (form == null) {
+                        messageSender.sendError(player, localizer.getMessage("error.invalidForm"));
+                        return;
+                    }
+
+                    conditionBag.accept(new WorldProximity(vector, form));
+
+                    // TODO: display region Maybe some day. In a far future...
+
+                    messageSender.sendMessage(player, localizer.getMessage("setCondition.proximity"));
+                })
+                .onTabComplete((sender, localizer, args) -> {
+                    final String[] proximityForm = Arrays.stream(WorldProximity.ProximityForm.values())
+                            .map(v -> v.name().toLowerCase())
+                            .toArray(String[]::new);
+
+                    if (args.length == 1) {
+                        return Arrays.asList("<" + localizer.getMessage("tabcomplete.dimensions") + ">", "<x,y,z>");
+                    }
+                    if (args.length == 2) {
+                        return ArrayUtil.startingWithInArray(args[1], proximityForm).collect(Collectors.toList());
+                    }
+                    return Collections.emptyList();
+                })
+                .withMeta("worldProximity", "worldLocation", ConditionContainer.Builder.Cost.PLAYER_LOW.cost)
+                .build();
+    }
+
+    @Override
+    public Boolean isOpen(Player player, World world, ConditionalDoor door, boolean currentState) {
+        for (Player worldPlayer : world.getPlayers()) {
+            Vector vector = worldPlayer.getLocation().toVector();
+            if (proximityForm.check.apply(door.getPosition(),
+                    new Vector(vector.getBlockX(), vector.getBlockY(), vector.getBlockZ()),
+                    dimensions)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public Component getDescription(ILocalizer localizer) {
+        Optional<ConditionContainer> containerByClass = ConditionRegistrar.getContainerByClass(getClass());
+
+        return Component.text(
+                localizer.getMessage("conditionDesc.type.proximity",
+                        Replacement.create("NAME", containerByClass
+                                .map(ConditionContainer::getName).orElse("undefined"))), NamedTextColor.AQUA)
+                .append(Component.newline())
+                .append(Component.text(localizer.getMessage("conditionDesc.size") + " ", C.baseColor))
+                .append(Component.text(dimensions.toString(), C.highlightColor))
+                .append(Component.newline())
+                .append(Component.text(localizer.getMessage("conditionDesc.proximityForm") + " ", C.baseColor))
+                .append(Component.text(localizer.getMessage(proximityForm.localKey), C.highlightColor));
+    }
+
+    @Override
+    public String getCreationCommand(ConditionalDoor door) {
+        return SET_COMMAND + door.getDoorUID() + " proximity "
+                + dimensions.getX() + "," + dimensions.getY() + "," + dimensions.getZ()
+                + " " + proximityForm.name().toLowerCase();
+    }
+
+    @Override
+    public WorldProximity clone() {
+        return new WorldProximity(dimensions, proximityForm);
+    }
+
+    @Override
+    public @NotNull Map<String, Object> serialize() {
+        return SerializationUtil.newBuilder()
+                .add("dimensions", dimensions)
+                .add("proximityForm", proximityForm)
+                .build();
+    }
+
+    public enum ProximityForm {
+        CUBOID("conditionDesc.proximityForm.cuboid",
+                (point, target, dimensions) -> {
+                    if (Math.abs(point.getX() - target.getX()) > dimensions.getX()) return false;
+                    if (Math.abs(point.getY() - target.getY()) > dimensions.getY()) return false;
+                    return !(Math.abs(point.getZ() - target.getZ()) > dimensions.getZ());
+                }),
+        ELLIPSOID("conditionDesc.proximityForm.ellipsoid",
+                (point, target, dimensions) ->
+                        Math.pow((target.getX() - point.getX()) / dimensions.getX(), 2)
+                                + Math.pow((target.getY() - point.getY()) / dimensions.getY(), 2)
+                                + Math.pow((target.getZ() - point.getZ()) / dimensions.getZ(), 2) <= 1),
+        CYLINDER("conditionDesc.proximityForm.cylinder",
+                (point, target, dimensions) -> {
+                    if (Math.abs(point.getY() - target.getY()) > dimensions.getY()) return false;
+                    return Math.pow(target.getX() - point.getX(), 2) / Math.pow(dimensions.getX(), 2)
+                            + Math.pow(target.getZ() - point.getZ(), 2) / Math.pow(dimensions.getZ(), 2) <= 1;
+                });
+
+        /**
+         * point, target, dimension
+         */
+        public TriFunction<Vector, Vector, Vector, Boolean> check;
+        public final String localKey;
+
+        ProximityForm(String localKey, TriFunction<Vector, Vector, Vector, Boolean> check) {
+            this.localKey = localKey;
+            this.check = check;
+        }
+    }
+}

--- a/src/main/java/de/eldoria/bigdoorsopener/conditions/worldlocation/WorldRegion.java
+++ b/src/main/java/de/eldoria/bigdoorsopener/conditions/worldlocation/WorldRegion.java
@@ -1,0 +1,168 @@
+package de.eldoria.bigdoorsopener.conditions.worldlocation;
+
+import com.google.common.cache.Cache;
+import com.sk89q.worldedit.bukkit.BukkitAdapter;
+import com.sk89q.worldguard.protection.managers.RegionManager;
+import com.sk89q.worldguard.protection.regions.ProtectedRegion;
+import com.sk89q.worldguard.protection.regions.RegionContainer;
+import de.eldoria.bigdoorsopener.core.BigDoorsOpener;
+import de.eldoria.bigdoorsopener.core.conditions.ConditionContainer;
+import de.eldoria.bigdoorsopener.core.conditions.ConditionRegistrar;
+import de.eldoria.bigdoorsopener.core.conditions.Scope;
+import de.eldoria.bigdoorsopener.door.ConditionalDoor;
+import de.eldoria.bigdoorsopener.util.C;
+import de.eldoria.eldoutilities.localization.ILocalizer;
+import de.eldoria.eldoutilities.localization.Replacement;
+import de.eldoria.eldoutilities.serialization.SerializationUtil;
+import de.eldoria.eldoutilities.serialization.TypeResolvingMap;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.configuration.serialization.SerializableAs;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+
+import static de.eldoria.bigdoorsopener.commands.CommandHelper.argumentsInvalid;
+
+/**
+ * A condition which opens the door, when a player is inside a world guard region.
+ */
+@SerializableAs("worldRegionCondition")
+public class WorldRegion implements WorldLocation {
+    private final ProtectedRegion region;
+    private final World world;
+    private final String worldName;
+    private final String regionId;
+
+    private final Cache<Location, Boolean> cache = C.getExpiringCache();
+
+    public WorldRegion(ProtectedRegion region, World world) {
+        this.region = region;
+        this.world = world;
+        this.worldName = world.getName();
+        this.regionId = region.getId();
+    }
+
+    private WorldRegion(World world, ProtectedRegion region, String regionId, String worldName) {
+        this.world = world;
+        this.region = region;
+        this.worldName = worldName;
+        this.regionId = regionId;
+    }
+
+    public WorldRegion(Map<String, Object> map) {
+        TypeResolvingMap resolvingMap = SerializationUtil.mapOf(map);
+        worldName = resolvingMap.getValue("world");
+        regionId = resolvingMap.getValue("region");
+        if (BigDoorsOpener.getRegionContainer() != null) {
+            world = Bukkit.getWorld(worldName);
+            if (world == null) {
+                region = null;
+                return;
+            }
+            region = BigDoorsOpener.getRegionContainer().get(BukkitAdapter.adapt(world)).getRegion(regionId);
+            return;
+        }
+        world = null;
+        region = null;
+        BigDoorsOpener.logger().warning("A region key is used but world guard was not found.");
+    }
+
+    public static ConditionContainer getConditionContainer() {
+        return ConditionContainer.ofClass(WorldRegion.class, Scope.WORLD)
+                .withFactory((player, messageSender, conditionBag, arguments) -> {
+                    final RegionContainer regionContainer = BigDoorsOpener.getRegionContainer();
+                    ILocalizer localizer = BigDoorsOpener.localizer();
+                    if (regionContainer == null) {
+                        messageSender.sendError(player, localizer.getMessage("error.wgNotEnabled"));
+                        return;
+                    }
+
+                    if (argumentsInvalid(player, messageSender, localizer, arguments, 1,
+                            "<" + localizer.getMessage("syntax.doorId") + "> <"
+                                    + localizer.getMessage("syntax.condition") + "> <"
+                                    + localizer.getMessage("tabcomplete.regionName") + ">")) {
+                        return;
+                    }
+
+                    if (player == null) {
+                        messageSender.sendError(null, localizer.getMessage("error.notAllowedFromConsole"));
+                        return;
+                    }
+                    RegionManager rm = regionContainer.get(BukkitAdapter.adapt(player.getWorld()));
+                    if (rm == null) {
+                        messageSender.sendError(player, localizer.getMessage("error.regionNotFound"));
+                        return;
+                    }
+                    ProtectedRegion region = rm.getRegion(arguments[0]);
+                    if (region == null) {
+                        messageSender.sendError(player, localizer.getMessage("error.regionNotFound"));
+                        return;
+                    }
+                    conditionBag.accept(new WorldRegion(region, player.getWorld()));
+                    messageSender.sendMessage(player, localizer.getMessage("setCondition.region"));
+
+                })
+                .onTabComplete((sender, localizer, args) -> {
+                    if (args.length == 1) {
+                        return Collections.singletonList("<" + localizer.getMessage("tabcomplete.regionName") + ">");
+                    }
+                    return Collections.emptyList();
+                })
+                .withMeta("worldRegion", "worldLocation", ConditionContainer.Builder.Cost.PLAYER_MEDIUM.cost)
+                .build();
+    }
+
+    @Override
+    public Boolean isOpen(Player player, World world, ConditionalDoor door, boolean currentState) {
+        if (world != this.world) return false;
+        if (region == null) return null;
+        for (Player worldPlayer : world.getPlayers()) {
+            if (region.contains(BukkitAdapter.asBlockVector(worldPlayer.getLocation()))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public Component getDescription(ILocalizer localizer) {
+        Optional<ConditionContainer> containerByClass = ConditionRegistrar.getContainerByClass(getClass());
+
+        return Component.text(
+                localizer.getMessage("conditionDesc.type.region",
+                        Replacement.create("NAME", containerByClass
+                                .map(ConditionContainer::getName).orElse("undefined"))), NamedTextColor.AQUA)
+                .append(Component.newline())
+                .append(Component.text(localizer.getMessage("conditionDesc.region") + " ", C.baseColor))
+                .append(Component.text(regionId, C.highlightColor))
+                .append(Component.newline())
+                .append(Component.text(localizer.getMessage("conditionDesc.world") + " ", C.baseColor))
+                .append(Component.text(worldName, C.highlightColor));
+    }
+
+    @Override
+    public String getCreationCommand(ConditionalDoor door) {
+        return SET_COMMAND + door.getDoorUID() + " region " + regionId;
+    }
+
+    @Override
+    public WorldRegion clone() {
+        return new WorldRegion(world, region, worldName, regionId);
+    }
+
+    @Override
+    public @NotNull Map<String, Object> serialize() {
+        return SerializationUtil.newBuilder()
+                .add("world", worldName)
+                .add("region", regionId)
+                .build();
+    }
+
+}

--- a/src/main/java/de/eldoria/bigdoorsopener/conditions/worldlocation/WorldSimpleRegion.java
+++ b/src/main/java/de/eldoria/bigdoorsopener/conditions/worldlocation/WorldSimpleRegion.java
@@ -1,0 +1,141 @@
+package de.eldoria.bigdoorsopener.conditions.worldlocation;
+
+import com.google.common.cache.Cache;
+import de.eldoria.bigdoorsopener.core.BigDoorsOpener;
+import de.eldoria.bigdoorsopener.core.conditions.ConditionContainer;
+import de.eldoria.bigdoorsopener.core.conditions.ConditionRegistrar;
+import de.eldoria.bigdoorsopener.core.conditions.Scope;
+import de.eldoria.bigdoorsopener.core.listener.registration.InteractionRegistrationObject;
+import de.eldoria.bigdoorsopener.core.listener.registration.RegisterInteraction;
+import de.eldoria.bigdoorsopener.door.ConditionalDoor;
+import de.eldoria.bigdoorsopener.util.C;
+import de.eldoria.eldoutilities.localization.ILocalizer;
+import de.eldoria.eldoutilities.localization.Replacement;
+import de.eldoria.eldoutilities.messages.MessageSender;
+import de.eldoria.eldoutilities.serialization.SerializationUtil;
+import de.eldoria.eldoutilities.serialization.TypeResolvingMap;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.configuration.serialization.SerializableAs;
+import org.bukkit.entity.Player;
+import org.bukkit.event.block.Action;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.util.BlockVector;
+import org.bukkit.util.Vector;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+@SerializableAs("worldSimpleRegionCondition")
+public class WorldSimpleRegion implements WorldLocation {
+    private final BlockVector minimum;
+    private final BlockVector maximum;
+    private final String world;
+
+    private final Cache<Location, Boolean> cache = C.getExpiringCache(10, TimeUnit.SECONDS);
+
+    public WorldSimpleRegion(BlockVector first, BlockVector second, String world) {
+        this.world = world;
+        this.minimum = BlockVector.getMinimum(first, second).toBlockVector();
+        this.maximum = BlockVector.getMaximum(first, second).toBlockVector();
+    }
+
+    public WorldSimpleRegion(Map<String, Object> map) {
+        TypeResolvingMap resolvingMap = SerializationUtil.mapOf(map);
+        minimum = resolvingMap.getValue("minimum");
+        maximum = resolvingMap.getValue("maximum");
+        world = resolvingMap.getValue("world");
+    }
+
+    public static ConditionContainer getConditionContainer() {
+        return ConditionContainer.ofClass(WorldSimpleRegion.class, Scope.WORLD)
+                .withFactory((player, messageSender, conditionBag, arguments) -> {
+                    ILocalizer localizer = BigDoorsOpener.localizer();
+                    messageSender.sendMessage(player, localizer.getMessage("setCondition.firstPoint"));
+                    RegisterInteraction.getInstance().register(player, new InteractionRegistrationObject() {
+                        private String world;
+                        private BlockVector first;
+
+                        @Override
+                        public boolean invoke(PlayerInteractEvent event, MessageSender messageSender) {
+                            if (event.getAction() != Action.LEFT_CLICK_BLOCK) {
+                                return false;
+                            }
+                            BlockVector vec = event.getClickedBlock().getLocation().toVector().toBlockVector();
+                            if (first == null) {
+                                world = event.getPlayer().getWorld().getName();
+                                first = vec;
+                                event.setCancelled(true);
+                                messageSender.sendMessage(player, localizer.getMessage("setCondition.secondPoint"));
+                                return false;
+                            }
+                            conditionBag.accept(new WorldSimpleRegion(first, vec, world));
+                            event.setCancelled(true);
+                            messageSender.sendMessage(player, localizer.getMessage("setCondition.simpleRegionRegisterd"));
+                            return true;
+                        }
+                    });
+
+                })
+                .onTabComplete((sender, localizer, args) -> Collections.emptyList())
+                .withMeta("worldSimpleRegion", "worldLocation", ConditionContainer.Builder.Cost.PLAYER_LOW.cost)
+                .build();
+    }
+
+    @Override
+    public Boolean isOpen(Player player, World world, ConditionalDoor door, boolean currentState) {
+        for (Player worldPlayer : world.getPlayers()) {
+            Vector pos = player.getLocation().toVector();
+            if (pos.getX() > maximum.getX() || pos.getX() < minimum.getX()) continue;
+            if (pos.getY() > maximum.getY() || pos.getY() < minimum.getY()) continue;
+            if (!(pos.getZ() > maximum.getZ()) && !(pos.getZ() < minimum.getZ())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public Component getDescription(ILocalizer localizer) {
+        Optional<ConditionContainer> containerByClass = ConditionRegistrar.getContainerByClass(getClass());
+
+        return Component.text(
+                localizer.getMessage("conditionDesc.type.simpleRegion",
+                        Replacement.create("NAME", containerByClass
+                                .map(ConditionContainer::getName).orElse("undefined"))), NamedTextColor.AQUA)
+                .append(Component.newline())
+                .append(Component.text(localizer.getMessage("conditionDesc.world") + " ", C.baseColor))
+                .append(Component.text(world, C.highlightColor))
+                .append(Component.newline())
+                .append(Component.text(localizer.getMessage("conditionDesc.minPoint") + " ", C.baseColor))
+                .append(Component.text(minimum.toString(), C.highlightColor))
+                .append(Component.newline())
+                .append(Component.text(localizer.getMessage("conditionDesc.maxPoint") + " ", C.baseColor))
+                .append(Component.text(maximum.toString(), C.highlightColor));
+    }
+
+    @Override
+    public String getCreationCommand(ConditionalDoor door) {
+        return SET_COMMAND + door.getDoorUID() + " simpleRegion";
+    }
+
+    @Override
+    public WorldSimpleRegion clone() {
+        return new WorldSimpleRegion(minimum, maximum, world);
+    }
+
+    @Override
+    public @NotNull Map<String, Object> serialize() {
+        return SerializationUtil.newBuilder()
+                .add("minimum", minimum)
+                .add("maximum", maximum)
+                .add("world", world)
+                .build();
+    }
+
+}

--- a/src/main/java/de/eldoria/bigdoorsopener/config/Config.java
+++ b/src/main/java/de/eldoria/bigdoorsopener/config/Config.java
@@ -122,17 +122,17 @@ public class Config {
                 ConditionBag conditionBag = cD.getConditionBag();
 
                 if (tD.getPermission() != null && !tD.getPermission().isEmpty()) {
-                    conditionBag.putCondition(new PermissionNode(tD.getPermission()));
+                    conditionBag.setCondition(new PermissionNode(tD.getPermission()));
                     log.info("Adding permission condition.");
                 }
 
                 if (!tD.isPermanentlyClosed()) {
-                    conditionBag.putCondition(new Time(tD.getTicksOpen(), tD.getTicksClose(), false));
+                    conditionBag.setCondition(new Time(tD.getTicksOpen(), tD.getTicksClose(), false));
                     log.info("Adding time condition.");
                 }
 
                 if (tD.getOpenRange() > 0) {
-                    conditionBag.putCondition(
+                    conditionBag.setCondition(
                             new Proximity(
                                     new Vector(tD.getOpenRange(), tD.getOpenRange(), tD.getOpenRange()),
                                     Proximity.ProximityForm.ELLIPSOID));

--- a/src/main/java/de/eldoria/bigdoorsopener/core/conditions/ConditionGroup.java
+++ b/src/main/java/de/eldoria/bigdoorsopener/core/conditions/ConditionGroup.java
@@ -17,7 +17,6 @@ public class ConditionGroup {
         this.name = name;
     }
 
-
     void addCondition(ConditionContainer condition) {
         conditions.put(condition.getName(), condition);
     }
@@ -28,5 +27,9 @@ public class ConditionGroup {
 
     public Optional<ConditionContainer> getConditionByName(String name) {
         return Optional.ofNullable(conditions.get(name));
+    }
+
+    public Scope getScope() {
+        return conditions.values().stream().findFirst().map(ConditionContainer::getScope).orElse(null);
     }
 }

--- a/src/main/java/de/eldoria/bigdoorsopener/door/ConditionalDoor.java
+++ b/src/main/java/de/eldoria/bigdoorsopener/door/ConditionalDoor.java
@@ -102,7 +102,7 @@ public class ConditionalDoor implements ConfigurationSerializable {
         if (resolvingMap.containsKey("conditionChain")) {
             ConditionChain conditionChain = resolvingMap.getValue("conditionChain");
             conditionBag = new ConditionBag();
-            conditionChain.getConditions().stream().filter(java.util.Objects::nonNull).forEach(c -> conditionBag.putCondition(c));
+            conditionChain.getConditions().stream().filter(java.util.Objects::nonNull).forEach(c -> conditionBag.setCondition(c));
         } else {
             conditionBag = resolvingMap.getValueOrDefault("conditionBag", new ConditionBag());
         }

--- a/src/main/java/de/eldoria/bigdoorsopener/util/CachingJSEngine.java
+++ b/src/main/java/de/eldoria/bigdoorsopener/util/CachingJSEngine.java
@@ -18,77 +18,86 @@ import java.util.logging.Level;
  * which it should be anyway.
  */
 public class CachingJSEngine {
-	private final Cache<String, Object> cache;
-	private ScriptEngine engine;
+    private final Cache<String, Object> cache;
+    private ScriptEngine engine;
 
-	public CachingJSEngine(int cacheSize) {
-		try {
-			String[] versionString = System.getProperty("java.specification.version").split("\\.");
-			String version = versionString[versionString.length - 1];
-			if (Integer.parseInt(version) < 11) {
-				this.engine = (new NashornScriptEngineFactory()).getScriptEngine();
-			} else if (Integer.parseInt(version) < 15) {
-				this.engine = (new NashornScriptEngineFactory()).getScriptEngine("--no-deprecation-warning");
-			} else {
+    public CachingJSEngine(int cacheSize) {
+        try {
+            BigDoorsOpener.logger().info("Java version: " + System.getProperty("java.specification.version"));
+            String[] versionString = System.getProperty("java.specification.version").split("\\.");
+            String version = versionString[versionString.length - 1];
+            int verInt = Integer.parseInt(version);
+            BigDoorsOpener.logger().info("Detected version: " + verInt);
+            if (verInt < 11) {
+                BigDoorsOpener.logger().info("Detected legacy java version below 11.");
+                this.engine = new NashornScriptEngineFactory().getScriptEngine();
+            } else if (verInt < 15) {
+                BigDoorsOpener.logger().info("Java 11 or newer detected.");
+                this.engine = new NashornScriptEngineFactory().getScriptEngine("--no-deprecation-warning");
+            } else {
                 this.engine = new ScriptEngineManager(null).getEngineByName("JavaScript");
             }
-			this.engine.eval("print('[BigDoorsOpener] nashorn script engine started.')");
-		} catch (ScriptException e) {
-			BigDoorsOpener.logger().info("No nashorn script engine found. Trying to use JavaScript fallback.");
-			engine = new ScriptEngineManager(null).getEngineByName("JavaScript");
-			try {
-				engine.eval("print('[BigDoorsOpener] JavaScript script engine started.')");
-			} catch (ScriptException ex) {
-				BigDoorsOpener.logger().warning("Could not start script engine. Custom evaluator will not work.");
-			}
-		}
+            this.engine.eval("print('[BigDoorsOpener] nashorn script engine started.')");
+        } catch (ScriptException e) {
+            BigDoorsOpener.logger().log(Level.WARNING, "No nashorn script engine found. Trying to use JavaScript fallback.", e);
+            engine = new ScriptEngineManager(null).getEngineByName("JavaScript");
+            try {
+                engine.eval("print('[BigDoorsOpener] JavaScript script engine started.')");
+            } catch (ScriptException ex) {
+                BigDoorsOpener.logger().log(Level.WARNING, "Could not start script engine. Custom evaluator will not work.", e);
+            }
+        } catch (RuntimeException e) {
+            BigDoorsOpener.logger().log(Level.WARNING, "Could not start script engine. Custom evaluator will not work.", e);
 
-		cache = CacheBuilder.newBuilder().expireAfterAccess(24, TimeUnit.MINUTES).maximumSize(500).build();
-	}
+        }
 
-	/**
-	 * Evaluates a string with a js engine.
-	 *
-	 * @param string       string to evaluate
-	 * @param defaultValue default value which should be returned if anything goes wrong.
-	 * @param <T>          type which should be returned
-	 *
-	 * @return evaluated value or default value
-	 */
-	@SuppressWarnings("unchecked")
-	public <T> T eval(String string, T defaultValue) {
-		try {
-			return evalUnsafe(string, defaultValue);
-		} catch (ScriptException e) {
-			BigDoorsOpener.logger().log(Level.WARNING,
-					"An error occurred while evaluating \"" + string + "\"", e);
-			return defaultValue;
-		} catch (ClassCastException e) {
-			BigDoorsOpener.logger().log(Level.WARNING,
-					"Could not map result.", e);
-			return defaultValue;
-		} catch (ExecutionException e) {
-			BigDoorsOpener.logger().log(Level.WARNING,
-					"Could not compute cache value for " + string + ".", e);
-			return defaultValue;
-		}
-	}
 
-	/**
-	 * @param string       string to evaluate
-	 * @param defaultValue default value which should be returned if anything goes wrong.
-	 * @param <T>          type which should be returned
-	 *
-	 * @return evaluated value or default value if evaluated value is null.
-	 *
-	 * @throws ExecutionException if a exception occured while creating the cached value
-	 * @throws ScriptException    if a exception orccured while executing the js script
-	 * @throws ClassCastException if the received object cant be cast on the requested type
-	 */
-	@SuppressWarnings("unchecked")
-	public <T> T evalUnsafe(String string, T defaultValue) throws ExecutionException, ScriptException, ClassCastException {
-		Object t = cache.get(string, () -> engine.eval(string));
-		if (t == null) return defaultValue;
-		return (T) t;
-	}
+        cache = CacheBuilder.newBuilder().expireAfterAccess(24, TimeUnit.MINUTES).maximumSize(500).build();
+    }
+
+    /**
+     * Evaluates a string with a js engine.
+     *
+     * @param string       string to evaluate
+     * @param defaultValue default value which should be returned if anything goes wrong.
+     * @param <T>          type which should be returned
+     *
+     * @return evaluated value or default value
+     */
+    @SuppressWarnings("unchecked")
+    public <T> T eval(String string, T defaultValue) {
+        try {
+            return evalUnsafe(string, defaultValue);
+        } catch (ScriptException e) {
+            BigDoorsOpener.logger().log(Level.WARNING,
+                    "An error occurred while evaluating \"" + string + "\"", e);
+            return defaultValue;
+        } catch (ClassCastException e) {
+            BigDoorsOpener.logger().log(Level.WARNING,
+                    "Could not map result.", e);
+            return defaultValue;
+        } catch (ExecutionException e) {
+            BigDoorsOpener.logger().log(Level.WARNING,
+                    "Could not compute cache value for " + string + ".", e);
+            return defaultValue;
+        }
+    }
+
+    /**
+     * @param string       string to evaluate
+     * @param defaultValue default value which should be returned if anything goes wrong.
+     * @param <T>          type which should be returned
+     *
+     * @return evaluated value or default value if evaluated value is null.
+     *
+     * @throws ExecutionException if a exception occured while creating the cached value
+     * @throws ScriptException    if a exception orccured while executing the js script
+     * @throws ClassCastException if the received object cant be cast on the requested type
+     */
+    @SuppressWarnings("unchecked")
+    public <T> T evalUnsafe(String string, T defaultValue) throws ExecutionException, ScriptException, ClassCastException {
+        Object t = cache.get(string, () -> engine.eval(string));
+        if (t == null) return defaultValue;
+        return (T) t;
+    }
 }

--- a/src/main/java/de/eldoria/bigdoorsopener/util/Permissions.java
+++ b/src/main/java/de/eldoria/bigdoorsopener/util/Permissions.java
@@ -10,6 +10,7 @@ public final class Permissions {
 
     // permission to use all commands except reload
     public static final String USE = "bdo.command.use";
+    public static final String GIVE_KEY = "bdo.command.givekey";
     // permission to reload the plugin
     public static final String RELOAD = "bdo.command.reload";
     // permission to use a custom js evaluator

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -171,6 +171,7 @@ tabcomplete.regionName=region name
 tabcomplete.setTimed.close=close at ticks (0-24000) or time (HH:mm)
 tabcomplete.setTimed.open=open at ticks (0-24000) or time (HH:mm)
 tabcomplete.validValues=valid values
+tabcomplete.conditionId=Condition Id
 unregister.message=Door %DOOR_NAME% unregistered.
 warning.chainIsEmpty=The door has no conditions set. The door will not change its state. Maybe you want to unregister it instead.
 warning.valueNotInEvaluator=The condition %VALUE% is missing in the evaluator. It will not have any influence on the door state yet.

--- a/src/main/resources/messages_de_DE.properties
+++ b/src/main/resources/messages_de_DE.properties
@@ -171,6 +171,7 @@ tabcomplete.regionName=Region Name
 tabcomplete.setTimed.close=<Schließen bei Tick (0-24000) oder Zeit (HH:mm)>
 tabcomplete.setTimed.open=<Öffnen bei Tick (0-24000) oder Zeit (HH:mm)>
 tabcomplete.validValues=Gültige Werte
+tabcomplete.conditionId=Bedingung Id
 unregister.message=Tor %DOOR_NAME% wurde entfernt.
 warning.chainIsEmpty=Dieses Tor hat derzeit keine Bedingungen. Der Zustand wird sich nicht verändern. Vielleicht möchtest du sie lieber entfernen.
 warning.valueNotInEvaluator=Der Bedingung %VALUE% fehlt in der aktuellen Formel. Sie wird derzeit keinerlei Auswirkungen haben.

--- a/src/main/resources/messages_en_US.properties
+++ b/src/main/resources/messages_en_US.properties
@@ -171,6 +171,7 @@ tabcomplete.regionName=region name
 tabcomplete.setTimed.close=close at ticks (0-24000) or time (HH:mm)
 tabcomplete.setTimed.open=open at ticks (0-24000) or time (HH:mm)
 tabcomplete.validValues=valid values
+tabcomplete.conditionId=Condition Id
 unregister.message=Door %DOOR_NAME% unregistered.
 warning.chainIsEmpty=The door has no conditions set. The door will not change its state. Maybe you want to unregister it instead.
 warning.valueNotInEvaluator=The condition %VALUE% is missing in the evaluator. It will not have any influence on the door state yet.


### PR DESCRIPTION
Version 2.4.0 has some larger changes.
The permission for the givekey command changed to bdo.command.givekey.
Three new conditions for locations were added. These conditions all have the prefix "world". The current location checks had a player scope. Which means that a player would have to fullfill all player conditions. For example a player had to be in the region and needs the item for the item condition. The world condition will just check if any player is inside the region and if any player has the item.
This is usefull if you want to have two players in different regions to open a door.
To allow this it is now possible to add multiple conditions of the same type. Use the addcondition command instead of the setcondition command. If you dont want to use this feature just continue using the setcondition command. This command will always override all set conditions.

```diff
+ Added three new world conditions.
+ Added command to add conditions
+ Allow to add more then one condition of the same type
* The giveKey command now requires the bdo.command.givekey permission and no longer the bdo.command.use permission
* Fixed a bug which caused mythic mobs to not work correct
* Fixed a bug which
```